### PR TITLE
Make sure Copyright year is always up to date.

### DIFF
--- a/_includes/footer.html
+++ b/_includes/footer.html
@@ -2,7 +2,7 @@
       <div class="container">
         <div class="row">
           <div class="col-lg-12">
-            <p class="text-muted">&copy; 2015 Google</p>
+            <p class="text-muted">&copy; {{ 'now' | date: "%Y" }} Google</p>
           </div>
         </div>
       </div>


### PR DESCRIPTION
In a document comment, @sillsm said it was OK to have the copyright year showing the current date.

Instead of using a fixed date, I used the technique described at http://www.adamwadeharris.com/get-current-year-in-jekyll/