### PR TITLE
Do not use header anchors on Home page

### DIFF
--- a/_includes/footer.html
+++ b/_includes/footer.html
@@ -13,13 +13,6 @@
     <!-- Include all compiled plugins (below), or include individual files as needed -->
     <script src="/assets/js/bootstrap.min.js"></script>
 
-    <!-- Anchor JS -->
-    <script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/anchor-js/3.2.0/anchor.min.js"></script>
-    <script>
-      // Automatically add anchors and links to all header elements that don't already have them.
-      anchors.add();
-    </script>
-
     <script>
       var shiftWindow = function() {
         if (location.hash.length !== 0) {

--- a/_layouts/contribute.html
+++ b/_layouts/contribute.html
@@ -51,11 +51,5 @@ nav: contribute
     </div>
 
     {% include footer.html %}
-    <!-- Anchor JS -->
-    <script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/anchor-js/3.2.0/anchor.min.js"></script>
-    <script>
-      // Automatically add anchors and links to all header elements that don't already have them.
-      anchors.add();
-    </script>
   </body>
 </html>

--- a/_layouts/contribute.html
+++ b/_layouts/contribute.html
@@ -51,5 +51,11 @@ nav: contribute
     </div>
 
     {% include footer.html %}
+    <!-- Anchor JS -->
+    <script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/anchor-js/3.2.0/anchor.min.js"></script>
+    <script>
+      // Automatically add anchors and links to all header elements that don't already have them.
+      anchors.add();
+    </script>
   </body>
 </html>

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -17,5 +17,11 @@
     </div>
 
     {% include footer.html %}
+    <!-- Anchor JS -->
+    <script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/anchor-js/3.2.0/anchor.min.js"></script>
+    <script>
+      // Automatically add anchors and links to all header elements that don't already have them.
+      anchors.add();
+    </script>
   </body>
 </html>


### PR DESCRIPTION
Tested: locally

This prevents anchors to display on the Home page, where they disturbed centered items and where they were not necessary.