### PR TITLE
remove mailing list icon from topbar

### DIFF
--- a/_includes/header.html
+++ b/_includes/header.html
@@ -38,9 +38,8 @@
             <li{% if page.nav == "blog" %} class="active"{% endif %}>
               <a href="/blog">Blog</a>
             </li>
-            <li><a href="http://stackoverflow.com/questions/tagged/bazel" class="nav-icon"><i class="fa fa-stack-overflow"></i></a></li>
-            <li><a href="https://groups.google.com/forum/#!forum/bazel-discuss" class="nav-icon"><i class="fa fa-envelope"></i></a></li>
             <li><a href="https://twitter.com/bazelbuild" class="nav-icon"><i class="fa fa-twitter"></i></a></li>
+            <li><a href="http://stackoverflow.com/questions/tagged/bazel" class="nav-icon"><i class="fa fa-stack-overflow"></i></a></li>
           </ul>
         </div><!-- /.navbar-collapse -->
       </div><!-- /.container-fluid -->


### PR DESCRIPTION
We want to put forward StackOverflow when it comes to user questions.
Link to the mailing list is always accessible at https://bazel.build/versions/master/docs/support.html