### PR TITLE
Fix: page title color, index title

### DIFF
--- a/_layouts/contribute.html
+++ b/_layouts/contribute.html
@@ -10,7 +10,7 @@ nav: contribute
 
     <div class="page-title-bar">
       <div class="container">
-        <h1>Contribute!</h1>
+        <h1>Contribute</h1>
       </div>
     </div>
 

--- a/_sass/style.scss
+++ b/_sass/style.scss
@@ -3,6 +3,7 @@ $bazel-green: #43a047;
 $bazel-green-light: #76d275;
 $bazel-green-dark-left: #00701a;
 $bazel-green-dark-right: #004300;
+$color-on-bazel-green: #fff;
 
 $body-font-family: 'RobotoDraft', 'Helvetica Neue', Helvetica, Arial,
                    sans-serif;
@@ -173,11 +174,9 @@ $hero-padding: 40px;
   font-weight: bold;
 }
 
-$page-title-bar-bg-color: $bazel-green-light;
-$page-title-bar-color: $bazel-green;
 
 .page-title-bar {
-  background-color: $page-title-bar-bg-color;
+  background-color: $bazel-green-light;
   padding-top: 20px;
   padding-bottom: 20px;
 
@@ -188,7 +187,7 @@ $page-title-bar-color: $bazel-green;
   h5,
   h6 {
     margin: 8px 0 4px 0;
-    color: $page-title-bar-color;
+    color: $color-on-bazel-green;
   }
 }
 
@@ -217,10 +216,10 @@ $page-title-bar-color: $bazel-green;
 // Sidebar styles
 $navbar-bg-color: $bazel-green;
 $navbar-hover-bg-color: $bazel-green-light;
-$navbar-color: #fff;
+$navbar-color: $color-on-bazel-green;
 $navbar-hover-color: #444;
 $navbar-input-bg-color: $bazel-green-light;
-$navbar-input-focus-bg-color: #fff;
+$navbar-input-focus-bg-color: $color-on-bazel-green;
 $navbar-input-border-color: $bazel-green;
 
 .navbar-inverse {

--- a/index.html
+++ b/index.html
@@ -1,6 +1,6 @@
 ---
 layout: home
-title: Bazel: a fast, scalable, multi-language and extensible build system
+title: Bazel - a fast, scalable, multi-language and extensible build system"
 ---
 
 <div class="hero">


### PR DESCRIPTION
- The index page was broken due to the ":" character in the title.
- The main page titles were green on green, I am now using white.

![9pmobf66mff](https://cloud.githubusercontent.com/assets/360895/26682567/30a5f460-46e1-11e7-9638-bbba7994a6fe.png)
