### PR TITLE
Improvements to landing page.

### DIFF
--- a/_sass/home.scss
+++ b/_sass/home.scss
@@ -1,17 +1,18 @@
+$landing-bg-color: #fafafa;
+
+.body-home {
+  background-color: $landing-bg-color;
+}
+
 .home {
   $shared-padding: 40px;
-  $landing-alternate-bg-color: #fafafa;
   $logos-padding: $shared-padding;
+  $landing-alternate-bg-color: #fff;
   $section-padding: $shared-padding / 2;
   $text-light-color: #777;
 
   p, li {
     font-size: 16px;
-  }
-
-  h2,
-  .tagline {
-    text-align: center;
   }
 
   h1 {
@@ -24,34 +25,49 @@
   }
 
   h3 {
-    font-size: 26px;
-  }
-  .features h3 {
-    height: 2em;
+    font-size: 24px;
   }
 
-
-  .buttons {
-    margin-top: $shared-padding;
-  }
-
-  .hero .logo {
+  .hero {
+    .logo {
       max-width: 150px;
       margin-top: 20px;
       margin-left: auto;
       margin-right: auto;
+    }
+
+    .hero-tagline {
+      font-size: 20px;
+      font-weight: 300;
+      margin-top: 40px;
+      margin-bottom: 20px;
+      color: #757575;
+    }
+
+    .hero-title {
+      margin-top: 0px;
+      font-size: 36px;
+    }
   }
 
-  .tagline {
-    margin-top: 20px;
-  }
+  .cta-buttons {
+    margin-top: $shared-padding;
 
-  .main-cta {
-    margin-left: $shared-padding;
+    .cta-main {
+      margin-left: $shared-padding;
+    }
   }
 
   blockquote {
     border-left: none;
+  }
+
+  .features {
+    h3 {
+      // This is needed to align the value statements since some headings span
+      // two rows.
+      height: 2em;
+    }
   }
 
   .users {
@@ -75,6 +91,10 @@
   .landing-section {
     padding-top: $section-padding;
     padding-bottom: $section-padding;
+
+    h2 {
+      text-align: center;
+    }
   }
 
   .logos {
@@ -82,18 +102,17 @@
     padding-bottom: $logos-padding;
   }
 
-  .hero,
-  .get-started,
-  .features {
+  .features,
+  .get-started {
     background-color: $landing-alternate-bg-color;
   }
 
   .beta {
-    padding-top: 20px;
+    padding-top: 40px;
     color: $text-light-color;
     p {
       font-size: 14px;
+      margin: 0;
     }
   }
-
 }

--- a/index.html
+++ b/index.html
@@ -6,14 +6,15 @@ title: Bazel - a fast, scalable, multi-language and extensible build system"
   <div class="landing-section hero">
     <div class="container">
       <div class="row">
-        <div class="col-md-8 lead">
-          <h1>Build and test software of any size, quickly and reliably</h1>
-          <p class="buttons">
+        <div class="col-md-8">
+          <p class="hero-tagline">{Fast, Correct} - Choose two</p>
+          <h1 class="hero-title">Build and test software of any size, quickly and reliably</h1>
+          <p class="cta-buttons">
             <a class="btn btn-lg"
                href="{{ site.docs_site_url }}/install.html">
                Get Bazel
             </a>
-            <a class="btn btn-success btn-lg main-cta"
+            <a class="btn btn-success btn-lg cta-main"
                href="{{ site.docs_site_url }}/getting-started.html">
                Get Started
             </a>
@@ -24,22 +25,6 @@ title: Bazel - a fast, scalable, multi-language and extensible build system"
                title="Bazel"
                alt="Bazel logo"
                class="logo img-responsive" />
-          <p class="tagline">{Fast, Correct} - Choose two</p>
-        </div>
-      </div>
-    </div>
-  </div>
-
-  <div class="landing-section summary">
-    <div class="container">
-      <div class="row">
-        <div class="col-sm-12">
-          <p>
-            Bazel is Google's build and test tool, now open-source and available to everyone.
-            By design, Bazel makes builds reproducible and only rebuilds what is necessary.
-            <br/>
-            It has built-in support for building both client and server software in a variety of programming languages, and is easily extensible.
-          </p>
         </div>
       </div>
     </div>


### PR DESCRIPTION
* **Unify main tagline and hero message.** Move the tagline above the
  summary so that the hero section is more visually balanced but use a
  smaller font size for the tagline so that the summary is still the
  most prominent.
* **Remove summary.** Most of the summary is already captured by the Why
  Bazel and other sections below and are thus redundant. The only thing
  that is not captured is that is Bazel is Google's build tool, and if
  we wish, we can make this point a bit more prominient somewhere.
* **CSS cleanups.** Adjust paddings of different sections on the landing
  page, Refactor some CSS classes in home.scss and adjust the background
  colors accordingly.