### PR TITLE
Fix layout for tablet devices

### DIFF
--- a/_includes/footer-content.html
+++ b/_includes/footer-content.html
@@ -1,6 +1,6 @@
 <div class="container">
   <div class="row">
-    <div class="col-md-2">
+    <div class="col-sm-4 col-md-2">
       <p>About</p>
       <ul class="list-unstyled">
         <li><a href="https://github.com/bazelbuild/bazel/wiki/Bazel-Users">Who's using Bazel</a></li>
@@ -9,7 +9,7 @@
         <li><a href="{{ site.main_site_url }}/governance.html">Governance Plan</a></li>
       </ul>
     </div>
-    <div class="col-md-2">
+    <div class="col-sm-4 col-md-2">
       <p>Support</p>
       <ul class="list-unstyled">
         <li><a href="http://stackoverflow.com/questions/tagged/bazel">Stack Overflow</a></li>
@@ -19,7 +19,7 @@
         <li><a href="{{ site.main_site_url }}/support.html">Support Policy</a></li>
       </ul>
     </div>
-    <div class="col-md-2">
+    <div class="col-sm-4 col-md-2">
       <p>Stay Connected</p>
       <ul class="list-unstyled">
         <li><a href="https://twitter.com/bazelbuild">Twitter</a></li>

--- a/_includes/header.html
+++ b/_includes/header.html
@@ -16,7 +16,12 @@
         <!-- Collect the nav links, forms, and other content for toggling -->
         <div class="collapse navbar-collapse" id="bs-example-navbar-collapse-1">
           <ul class="nav navbar-nav navbar-right">
-            <li><a href="https://github.com/bazelbuild/bazel">GitHub</a></li>
+            <li>
+              <a href="https://github.com/bazelbuild/bazel">
+                <span class="hidden-sm">GitHub</span>
+                <span class="nav-icon visible-sm"><i class="fa fa-github"></i></span>
+              </a>
+            </li>
           </ul>
           <form class="navbar-form navbar-right" action="/search.html" id="cse-search-box">
             <div class="form-group">
@@ -34,10 +39,23 @@
               <a href="{{ site.main_site_url }}/contributing.html">Contribute</a>
             </li>
             <li{% if page.nav == "blog" %} class="active"{% endif %}>
-              <a href="{{ site.blog_site_url }}">Blog</a>
+              <a href="{{ site.blog_site_url }}">
+                <span class="hidden-sm">Blog</span>
+                <span class="nav-icon visible-sm"><i class="fa fa-rss"></i></span>
+              </a>
             </li>
-            <li><a href="https://twitter.com/bazelbuild" class="nav-icon"><i class="fa fa-twitter"></i></a></li>
-            <li><a href="http://stackoverflow.com/questions/tagged/bazel" class="nav-icon"><i class="fa fa-stack-overflow"></i></a></li>
+            <li>
+              <a href="https://twitter.com/bazelbuild">
+                <span class="visible-xs">Twitter</span>
+                <span><i class="nav-icon fa fa-twitter hidden-xs"></i></span>
+              </a>
+            </li>
+            <li>
+              <a href="http://stackoverflow.com/questions/tagged/bazel">
+                <span class="visible-xs">StackOverflow</span>
+                <span><i class="nav-icon fa fa-stack-overflow hidden-xs"></i></span>
+              </a>
+            </li>
           </ul>
         </div><!-- /.navbar-collapse -->
       </div><!-- /.container-fluid -->

--- a/_sass/navbar.scss
+++ b/_sass/navbar.scss
@@ -14,7 +14,7 @@ $navbar-input-border-color: $bazel-green;
 
   .navbar-brand {
     padding-top: 12px;
-    
+
     .navbar-logo {
       height: 28px;
     }
@@ -38,10 +38,10 @@ $navbar-input-border-color: $bazel-green;
       color: $navbar-hover-color;
       background-color: $navbar-hover-bg-color;
     }
+  }
 
-    &.nav-icon {
-      font-size: 18px;
-    }
+   .navbar-nav .nav-icon {
+    font-size: 18px;
   }
 
   .navbar-nav > li.active > a {
@@ -90,7 +90,7 @@ $navbar-input-border-color: $bazel-green;
   }
 }
 
-@media (max-width: 768px) {
+@media (max-width: 767px) {
   #cse-search-box {
     margin-top: 0;
     margin-bottom: 0;

--- a/index.html
+++ b/index.html
@@ -66,6 +66,7 @@ title: Bazel - a fast, scalable, multi-language and extensible build system"
             Bazel runs on Windows, macOS, and Linux.
           </p>
         </div>
+        <div class="clearfix visible-sm-block"></div>
         <div class="col-sm-6 col-md-3">
           <h3>Scalable</h3>
           <p>
@@ -93,28 +94,28 @@ title: Bazel - a fast, scalable, multi-language and extensible build system"
       </div>
 
       <div class="row logos">
-        <div class="col-sm-2 user-logo-container">
+        <div class="col-sm-6 col-md-2 user-logo-container">
           <img class="user-logo" src="{{site_root}}images/user-logos/dropbox.svg" alt="Dropbox logo" title="Dropbox"/>
         </div>
-        <div class="col-sm-2 user-logo-container">
+        <div class="col-sm-6 col-md-2 user-logo-container">
           <img class="user-logo" src="{{site_root}}images/user-logos/stripe.svg" alt="Stripe logo" title="Stripe"/>
         </div>
-        <div class="col-sm-2 user-logo-container">
+        <div class="col-sm-6 col-md-2 user-logo-container">
           <img class="user-logo square" src="{{site_root}}images/user-logos/huawei.png" alt="Huawei logo" title="Huawei"/>
         </div>
-        <div class="col-sm-2 user-logo-container">
+        <div class="col-sm-6 col-md-2 user-logo-container">
           <img class="user-logo" src="{{site_root}}images/user-logos/google.svg" alt="Google logo" title="Google"/>
         </div>
-        <div class="col-sm-2 user-logo-container">
+        <div class="col-sm-6 col-md-2 user-logo-container">
           <img class="user-logo" src="{{site_root}}images/user-logos/braintree.svg" alt="Braintree logo" title="Braintree, a PayPal service"/>
         </div>
-        <div class="col-sm-2 user-logo-container">
+        <div class="col-sm-6 col-md-2 user-logo-container">
           <img class="user-logo" src="{{site_root}}images/user-logos/twosigma.svg" alt="Two Sigma logo" title="Two Sigma"/>
         </div>
       </div>
 
       <div class="row">
-        <div class="col-sm-4">
+        <div class="col-sm-12 col-md-4">
           <blockquote>
             <p>
               Bazel is the common build tool throughout Pinterest and has been instrumental in achieving fast, reproducible builds across our programming languages and platforms.
@@ -125,7 +126,7 @@ title: Bazel - a fast, scalable, multi-language and extensible build system"
             </div>
           </blockquote>
         </div>
-        <div class="col-sm-4">
+        <div class="col-sm-12 col-md-4">
           <blockquote>
             <p>
               Bazel provides a seamless and consistent build interface for different languages in a single system. It increased our productivity significantly.
@@ -137,7 +138,7 @@ title: Bazel - a fast, scalable, multi-language and extensible build system"
             </div>
           </blockquote>
         </div>
-        <div class="col-sm-4">
+        <div class="col-sm-12 col-md-4">
           <blockquote>
             <p>By switching to bazel we not only eliminated the overhead of maintaining multiple build systems, but also massively sped up our build and testing infrastructure.</p>
             <footer><cite>Michal Witkowski</cite>, Principal Tech Lead</footer>
@@ -158,22 +159,22 @@ title: Bazel - a fast, scalable, multi-language and extensible build system"
         </div>
       </div>
       <div class="row">
-        <div class="col-sm-3">
+        <div class="col-sm-6 col-md-3">
           <h3>Java</h3>
           <p>Follow our <a href="{{ site.docs_site_url }}/tutorial/java.html">Build Java tutorial</a>.
           </p>
         </div>
-        <div class="col-sm-3">
+        <div class="col-sm-6 col-md-3">
           <h3>C++</h3>
           <p>Follow our <a href="{{ site.docs_site_url }}/tutorial/cpp.html">Build C++ tutorial</a>.
           </p>
         </div>
-        <div class="col-sm-3">
+        <div class="col-sm-6 col-md-3">
           <h3>Android</h3>
           <p>Follow our <a href="{{ site.docs_site_url }}/tutorial/app.html">mobile app tutorial</a>.
           </p>
         </div>
-        <div class="col-sm-3">
+        <div class="col-sm-6 col-md-3">
           <h3>iOS</h3>
           <p>Follow our <a href="{{ site.docs_site_url }}/tutorial/app.html">mobile app tutorial</a>.
           </p>


### PR DESCRIPTION
* make navigation actions responsive: 
 - when in collapsed mode, use text
 - when in tablet mode use icons for GitHub and Blog
 - when larger, use text for GitHub and Blog
* quotes
* footer

I am waiting for https://github.com/bazelbuild/bazel-website/pull/40 to be merged to fix the hero message part

Fixes #41

Tablet:
![localhost-12345- 9](https://user-images.githubusercontent.com/360895/27637957-d8c8521a-5c11-11e7-9848-ab77ee24d2d7.png)

Desktop:
![localhost-12345- 10](https://user-images.githubusercontent.com/360895/27637959-da1e999e-5c11-11e7-88e0-ab2f10cb4624.png)

Mobile:
![localhost-12345- 11](https://user-images.githubusercontent.com/360895/27637968-e1a4ff14-5c11-11e7-851a-0d1815341a82.png)
