### PR TITLE
Update the release policy

### DIFF
--- a/support.md
+++ b/support.md
@@ -56,12 +56,11 @@ We regularly publish [binary releases of Bazel](https://github.com/bazelbuild/ba
 Every beginning of the month (we target the first business day of the month), we create a new release
 candidate for a new MINOR version (e.g. 0.6.0). The work is tracked by a [release bug on GitHub](https://github.com/bazelbuild/bazel/issues?q=is%3Aissue+is%3Aopen+label%3Arelease) which indicates
 the exact target date for the incoming month and assigned to the current Release Manager.
-Those release candidate should pass all our unit tests, and show no unwanted regression in the
+Those release candidates should pass all our unit tests, and show no unwanted regression in the
 projects tested on [ci.bazel.io](http://ci.bazel.io).
 
-We announce those release candidates on [bazel-discuss](https://groups.google.com/forum/#!forum/bazel-discuss);
-these are binaries that have passed all of our unit tests. Over the next days, we monitor community bug
-reports for regressions in release candidate.
+We announce those release candidates on [bazel-discuss](https://groups.google.com/forum/#!forum/bazel-discuss).
+Over the next days, we monitor community bug reports for regressions in release candidate.
 
 If no regressions are discovered, we officially release the candidate after two weeks. However,
 regressions can delay the release of a release candidate. If regressions are found, we apply
@@ -69,14 +68,13 @@ corresponding cherry-picks to the release candidate to fix those regressions. If
 regressions are found for two business days, but not before two week has elapsed since the first
 release candidate, we release it.
 
-After the release candidate is cut, we do not cherry-pick new features into release candidates.
+After a release candidate is cut, we do not cherry-pick new features into it.
 Moreover, if we discover that a new feature is buggy, we might decide to roll it back from a
 release candidate. Only critical, high-impact bugs will be fixed in a release candidate.
 
-A release can only be release on a day where the next day is a business day. The release manager
-should make sure they are available on the next day or delegate their responsabilities.
+A release can only be release on a day where the next day is a business day.
 
-If a regression is found on the latest release, a patch release can be emitted by applying the
+If a critical issue is found on the latest release, a patch release can be emitted by applying the
 corresponding cherry-pick to the release tag. Being another patch to an existing release, the
 release candidate for a patch release can be released after 2 business days.
 

--- a/support.md
+++ b/support.md
@@ -49,23 +49,34 @@ reported issues within 2 business days.
 
 ## Releases
 
-We regularly publish [binary releases of Bazel](https://github.com/bazelbuild/bazel/releases). To
-that end, we announce release candidates on
-[bazel-discuss](https://groups.google.com/forum/#!forum/bazel-discuss); these are binaries that have
-passed all of our unit tests. Over the next few days, we regression test all applicable build
-targets at Google. If you have a critical project using Bazel, we recommend that you establish an
-automated testing process that tracks the current release candidate, and report any regressions.
+We regularly publish [binary releases of Bazel](https://github.com/bazelbuild/bazel/releases).
 
-If no regressions are discovered, we officially release the candidate after a week. However,
+Every beginning of the month (we target the first business day of the month), we create a new release
+candidate for a new MINOR version (e.g. 0.6.0). The work is tracked by a [release bug on GitHub](https://github.com/bazelbuild/bazel/issues?q=is%3Aissue+is%3Aopen+label%3A%22Release+blocker%22+label%3A%22type%3A+process%22) which indicates
+the exact target date for the incoming month. Those release candidate should pass all our unit tests,
+and show no unwanted regression in the projects tested on [ci.bazel.io](http://ci.bazel.io).
+
+We announce those release candidates on [bazel-discuss](https://groups.google.com/forum/#!forum/bazel-discuss);
+these are binaries that have passed all of our unit tests. Over the next few days, we regression
+test all applicable build targets at Google. If you have a critical project using Bazel, we
+recommend that you establish an automated testing process that tracks the current release
+candidate, and report any regressions.
+
+If no regressions are discovered, we officially release the candidate after two week. However,
 regressions can delay the release of a release candidate. If regressions are found, we apply
 corresponding cherry-picks to the release candidate to fix those regressions. If no further
-regressions are found for two business days, but not before a week has elapsed since the first
+regressions are found for two business days, but not before two week has elapsed since the first
 release candidate, we release it.
+
+If we are unable to create a viable release candidate 2 business days after the target days or
+if we are unable to release a candidate by the end of the month, we will investigate and publish
+a proper post-mortem.
 
 ### Release versioning
 
 Version 0.1 is our first release marking the start of our beta phase. Until version 1.0.0, we
-increase the MINOR version every time we reach a [new milestone](http://bazel.build/roadmap.html).
+increase the MINOR version every time we do a new full release. We increase the PATCH version
+when a regression is found on a release that necessite a new release.
 
 Version 1.0.0 marks the end of our beta phase; afterwards, we will label each release with a
 version number of the form MAJOR.MINOR.PATCH according to the

--- a/support.md
+++ b/support.md
@@ -61,17 +61,20 @@ projects tested on [ci.bazel.io](http://ci.bazel.io).
 
 We announce those release candidates on [bazel-discuss](https://groups.google.com/forum/#!forum/bazel-discuss);
 these are binaries that have passed all of our unit tests. Over the next days, we monitor community bug
-reports for regression in release candidate.
+reports for regressions in release candidate.
 
-If no regressions are discovered, we officially release the candidate after two week. However,
+If no regressions are discovered, we officially release the candidate after two weeks. However,
 regressions can delay the release of a release candidate. If regressions are found, we apply
 corresponding cherry-picks to the release candidate to fix those regressions. If no further
 regressions are found for two business days, but not before two week has elapsed since the first
-release candidate, we release it. We do not cherry-pick non-regression bugfix (e.g., for
-bug that has always been there or bug on new features) or feature.
+release candidate, we release it.
+
+After the release candidate is cut, we do not cherry-pick new features into release candidates.
+Moreover, if we discover that a new feature is buggy, we might decide to roll it back from a
+release candidate. Only critical, high-impact bugs will be fixed in a release candidate.
 
 A release can only be release on a day where the next day is a business day. The release manager
-should make sure he is available on the next day or delegate its responsabilities.
+should make sure they are available on the next day or delegate their responsabilities.
 
 If a regression is found on the latest release, a patch release can be emitted by applying the
 corresponding cherry-pick to the release tag. Being another patch to an existing release, the
@@ -90,7 +93,7 @@ We are doing public post-mortems in the following cases:
 ### Testing
 
 We run nightly build of all the projects running on [ci.bazel.io](http://ci.bazel.io) using Bazel
-binaries built at head, and using the release binaries. We project going to be impacted by a
+binaries built at head, and using the release binaries. We notify projects going to be impacted by a
 breaking change. Google's internal continuous integraion test run all the applicable build targets
 at Google nightly.
 

--- a/support.md
+++ b/support.md
@@ -72,7 +72,7 @@ After a release candidate is cut, we do not cherry-pick new features into it.
 Moreover, if we discover that a new feature is buggy, we might decide to roll it back from a
 release candidate. Only critical, high-impact bugs will be fixed in a release candidate.
 
-A release can only be release on a day where the next day is a business day.
+A release can only be released on a day where the next day is a business day.
 
 If a critical issue is found on the latest release, a patch release can be emitted by applying the
 corresponding cherry-pick to the release tag. Being another patch to an existing release, the

--- a/support.md
+++ b/support.md
@@ -51,26 +51,53 @@ reported issues within 2 business days.
 
 We regularly publish [binary releases of Bazel](https://github.com/bazelbuild/bazel/releases).
 
+### Policy
+
 Every beginning of the month (we target the first business day of the month), we create a new release
-candidate for a new MINOR version (e.g. 0.6.0). The work is tracked by a [release bug on GitHub](https://github.com/bazelbuild/bazel/issues?q=is%3Aissue+is%3Aopen+label%3A%22Release+blocker%22+label%3A%22type%3A+process%22) which indicates
-the exact target date for the incoming month. Those release candidate should pass all our unit tests,
-and show no unwanted regression in the projects tested on [ci.bazel.io](http://ci.bazel.io).
+candidate for a new MINOR version (e.g. 0.6.0). The work is tracked by a [release bug on GitHub](https://github.com/bazelbuild/bazel/issues?q=is%3Aissue+is%3Aopen+label%3Arelease) which indicates
+the exact target date for the incoming month and assigned to the current Release Manager.
+Those release candidate should pass all our unit tests, and show no unwanted regression in the
+projects tested on [ci.bazel.io](http://ci.bazel.io).
 
 We announce those release candidates on [bazel-discuss](https://groups.google.com/forum/#!forum/bazel-discuss);
-these are binaries that have passed all of our unit tests. Over the next few days, we regression
-test all applicable build targets at Google. If you have a critical project using Bazel, we
-recommend that you establish an automated testing process that tracks the current release
-candidate, and report any regressions.
+these are binaries that have passed all of our unit tests. Over the next days, we monitor community bug
+reports for regression in release candidate.
 
 If no regressions are discovered, we officially release the candidate after two week. However,
 regressions can delay the release of a release candidate. If regressions are found, we apply
 corresponding cherry-picks to the release candidate to fix those regressions. If no further
 regressions are found for two business days, but not before two week has elapsed since the first
-release candidate, we release it.
+release candidate, we release it. We do not cherry-pick non-regression bugfix (e.g., for
+bug that has always been there or bug on new features) or feature.
 
-If we are unable to create a viable release candidate 2 business days after the target days or
-if we are unable to release a candidate by the end of the month, we will investigate and publish
-a proper post-mortem.
+A release can only be release on a day where the next day is a business day. The release manager
+should make sure he is available on the next day or delegate its responsabilities.
+
+If a regression is found on the latest release, a patch release can be emitted by applying the
+corresponding cherry-pick to the release tag. Being another patch to an existing release, the
+release candidate for a patch release can be released after 2 business days.
+
+### Post-mortems
+
+We are doing public post-mortems in the following cases:
+
+- We are unable to create a viable release candidate 2 business days after the target day,
+- We are unable to release a candidate by the end of the month,
+- An emergency patch release is needed (a regression that cause the current binary to increase
+  the support load, e.g. several users report the same issue after a package manager update to
+  the new release).
+
+### Testing
+
+We run nightly build of all the projects running on [ci.bazel.io](http://ci.bazel.io) using Bazel
+binaries built at head, and using the release binaries. We project going to be impacted by a
+breaking change. Google's internal continuous integraion test run all the applicable build targets
+at Google nightly.
+
+When a release candidate is issued, we test more projects at Google like [TensorFlow](https://tensorflow.org)
+on their complete test suite using the release candidate binaries. If you have a critical project
+using Bazel, we recommend that you establish an automated testing process that tracks the current
+release candidate, and report any regressions.
 
 ### Release versioning
 


### PR DESCRIPTION
* Add the target date at the beginning of the month
* Set the release window to 2 weeks
* Change the numbering scheme
* Add post-mortem conditions

This is the reflection of the changes to the release process following the discussion on https://docs.google.com/document/d/1hTu-uU7l9KWCVAB5ugXgmIr-fagzsMfGjrz1IMEMw6Q

__Rationale__:
  - Since we have a monthly release, let's enforce the cadence. It helps us be more disciplined on our release and might helps people plan for testing our release.
  - 2 weeks windows since we have a monthly release and we generally do not release within the one week window.
  - We are dropping the release numbering following milestones, since we just keep on missing those.
  - Post-mortem condition will help us improve our release over time.

__Note__: Maybe we should also phrase more strictly the part about cherry-picking only regression.