### PR TITLE
Add "Get Support" page to the left nav

### DIFF
--- a/_layouts/contribute.html
+++ b/_layouts/contribute.html
@@ -29,6 +29,7 @@ nav: contribute
               <li><a href="/roadmap.html">Roadmap</a></li>
               <li><a href="/governance.html">Governance</a></li>
               <li><a href="/naming.html">Naming Bazel projects</a></li>
+              <li><a href="/support.html">Support</a></li>
             </ul>
             <h3>Technical Docs</h3>
             <ul class="sidebar-nav">


### PR DESCRIPTION
This support page needs to be somewhere on the left nav. I've added it to the "contribute" section because it's here in the website repo.

However - if this is meant primary for Bazel users, we should move the .md file and list it in the Documentation left nav. Thoughts?