### PR TITLE
Remove javascript redirects

### DIFF
--- a/_includes/head.html
+++ b/_includes/head.html
@@ -6,14 +6,7 @@
 
     <script>
       var current_url = window.location.href;
-      var bad_url = new RegExp("^https?://(bazelbuild.github.io/bazel|(www\.)?bazel.io)/");
-      if (bad_url.test(current_url)) {
-        window.location.replace(current_url.replace(bad_url, "https://bazel.build/"));
-      }
-      var http_url = new RegExp("^http://(www\.)?bazel.build/");
-      if (http_url.test(current_url)) {
-        window.location.replace(current_url.replace(http_url, "https://bazel.build/"));
-      }
+      
       // Do a shortcut so that be.bazel.build redirect to the build encyclopedia
       var be_url = new RegExp("^https?://be(\.bazel.build)?/?");
       if (be_url.test(current_url)) {


### PR DESCRIPTION
See: https://github.com/bazelbuild/bazel-website/issues/74 -- these js redirects are unnecessary now b/c they are handled by http redirector