### PR TITLE
Add links to new source.bazel.build site and corresponding docs.

### DIFF
--- a/_layouts/contribute.html
+++ b/_layouts/contribute.html
@@ -39,7 +39,11 @@ nav: contribute
             <h3>External Resources</h3>
             <ul class="sidebar-nav">
               <li><a href="https://github.com/bazelbuild/bazel">GitHub</a></li>
-              <li><a href="https://cs.bazel.build/">Search Bazel code</a><li>
+              <li><a href="https://source.bazel.build/">Search Bazel code</a>
+                <ul class="sidebar-nav">
+                  <li><a href="/browse-and-search-user-guide.html">Search user guide<li>
+                </ul>
+              </li>
               <li><a href="https://groups.google.com/forum/#!forum/bazel-dev">Developer mailing list</a></li>
               <li><a href="https://bazel-review.googlesource.com">Gerrit</a></li>
               <li><a href="irc://irc.freenode.net/bazel">IRC</a><li>

--- a/browse-and-search-user-guide.md
+++ b/browse-and-search-user-guide.md
@@ -172,6 +172,35 @@ To change either file, hover over the commit in the Change History pane. Then,
 click either the **Left** or **Right** button to have the open the commit on the
 left or right side of the diff.
 
+<a id="browsing-cross-references"></a>
+### Browsing cross references                                                                                                   
+
+Another way to browse source repositories is through the use of cross
+references. These references appear automatically as hyperlinks within a given
+source file.                                                                                                                   
+
+To make cross references easier to identify, click **Cross References**,
+located in the upper-right corner. This option displays an underline below all
+cross references in a file.
+
+Click a cross reference to open the Cross Reference pane. This pane contains
+two sections:
+
+* A **Definition** section, which lists the file or files that define the
+  reference
+* A **References** section, which lists the files in which the reference also
+  appears
+
+Both sections display the the name of the file, as well as the line or lines
+that contains the reference. To open a file from the Cross Reference pane,
+click the line number entry. The file appears in a new section of the pane,
+allowing you to continue to browse the file while keeping the original file
+in view.                                                                                                                       
+
+You can continue to browse cross references using the Cross Reference pane, just                                             
+as you can in the File pane. When you do, the pane displays a breadcrumb trail,                                                
+which you can use to navigate between different cross references.
+
 <a id="search"></a>
 ## Searching for code
 

--- a/browse-and-search-user-guide.md
+++ b/browse-and-search-user-guide.md
@@ -3,6 +3,7 @@ layout: contribute
 title: Browse and Search User Guide
 ---
 
+<a id="product-overview"></a>
 ## Product overview
 
 Bazel's [code search and source browsing interface](https://source.bazel.build)
@@ -10,6 +11,7 @@ is a web-based tool for browsing Bazel source code repositories. You can
 use these features to navigate among different repositories, branches, and
 files. You can also view history, diffs, and blame information.
 
+<a id="getting-started"></a>
 ## Getting started
 
 **Note:** For the best experience, use the latest version of Chrome, Safari, or
@@ -30,8 +32,10 @@ commit.
 At the top of the screen is a search box. You can use this box to search for
 specific files and code.
 
+<a id="working-with-repositories"></a>
 ## Working with repositories
 
+<a id="opening-a-repository"></a>
 ### Opening a repository
 
 To open a repository, click its name from the main screen.
@@ -42,10 +46,12 @@ repository and allows you to move quickly to another location such as another
 repository, or another location within a repository, such as a file, branch, or
 commit.
 
+<a id="switch-repositories"></a>
 ### Switch repositories
 
 To switch to a different repository, select the repository from the Breadcrumb toolbar.
 
+<a id="view-a-repository-at-a-specific-commit"></a>
 ### View a repository at a specific commit
 
 To view a repository at a specific commit:
@@ -57,6 +63,7 @@ To view a repository at a specific commit:
 
 The interface now shows the repository as it existed at that commit.
 
+<a id="open-a-branch-commit-or-tag"></a>
 ### Open a branch, commit, or tag
 
 By default, the code search and source browsing interface opens a repository to
@@ -73,6 +80,7 @@ branch using a branch name, a tag name, or through a search box.
 *  To search for a branch, commit, or tag, select the corresponding item and
    type a search term in the search box.
 
+<a id="working-with-files"></a>
 ## Working with files
 
 When you select a repository from the main screen, the screen changes to display
@@ -91,12 +99,14 @@ three components:
 *  A **File path** box, which displays the name of the current file or folder
    and its corresponding path
 
+<a id="open-a-file"></a>
 ### Open a file
 
 You can open a file by browsing to its directory and selecting it. The view of
 the repository updates to show the contents of the file in the file pane, and
 its location in the repository in the tree pane.
 
+<a id="view-file-changes"></a>
 ### View file changes
 
 To view file changes:
@@ -106,6 +116,7 @@ To view file changes:
 
 The file pane updates to display who made changes to the file and when.
 
+<a id="view-change-history"></a>
 ### View change history
 
 To view the change history of a file:
@@ -114,6 +125,7 @@ To view the change history of a file:
 1.  Click **HISTORY**, located in the upper-right corner.
     The **Change history** pane appears, showing the commits for this file.
 
+<a id="view-code-reviews"></a>
 ### View code reviews
 
 For Gerrit code reviews, you can open the tool directly from the Change History pane.
@@ -129,6 +141,7 @@ To view the code review for a file:
 
 The Gerrit Code Review tool opens in a new browser window.
 
+<a id="open-a-file-at-a-specific-commit"></a>
 ### Open a file at a specific commit
 
 To open a file at a specific commit:
@@ -139,6 +152,7 @@ To open a file at a specific commit:
 1. Hover over a commit. A **VIEW** button appears.
 1. Click the **VIEW** button.
 
+<a id="compare-a-file-to-a-different-commit"></a>
 ### Compare a file to a different commit
 
 To compare a file at a different commit:
@@ -158,6 +172,7 @@ To change either file, hover over the commit in the Change History pane. Then,
 click either the **Left** or **Right** button to have the open the commit on the
 left or right side of the diff.
 
+<a id="search"></a>
 ## Searching for code
 
 You can search for specific files or code snippets using the search box located
@@ -240,6 +255,7 @@ f:</td>
 </tbody>
 </table>
 
+<a id="additional-support"></a>
 # Additional Support
 
 To report an issue, click the **Feedback** button that appears in the top right-hand corner of the screen and enter your feedback in the provided form.

--- a/browse-and-search-user-guide.md
+++ b/browse-and-search-user-guide.md
@@ -1,0 +1,245 @@
+---
+layout: contribute
+title: Browse and Search User Guide
+---
+
+## Product overview
+
+Bazel's [code search and source browsing interface](https://source.bazel.build)
+is a web-based tool for browsing Bazel source code repositories. You can
+use these features to navigate among different repositories, branches, and
+files. You can also view history, diffs, and blame information.
+
+## Getting started
+
+**Note:** For the best experience, use the latest version of Chrome, Safari, or
+Firefox.
+
+To access the code search and source browsing interface, open
+[https://source.bazel.build](https://source.bazel.build) in your web browser.
+
+The main screen appears. This screen contains the following components:
+
+1. The Breadcrumb toolbar. This toolbar displays your current location in the
+repository and allows you to move quickly to another location such as another
+repository, or another location within a repository, such as a file, branch, or
+commit.
+
+1. A list of repositories that you can browse.
+
+At the top of the screen is a search box. You can use this box to search for
+specific files and code.
+
+## Working with repositories
+
+### Opening a repository
+
+To open a repository, click its name from the main screen.
+
+Alternatively, you can use the Breadcrumb toolbar to browse for a
+specificrepository. This toolbar displays your current location in the
+repository and allows you to move quickly to another location such as another
+repository, or another location within a repository, such as a file, branch, or
+commit.
+
+### Switch repositories
+
+To switch to a different repository, select the repository from the Breadcrumb toolbar.
+
+### View a repository at a specific commit
+
+To view a repository at a specific commit:
+
+1. From the view of the repository, select the file.
+1. From the Breadcrumb toolbar, open the **Branch** menu.
+1. In the submenu that appears, click **Commit**.
+1. Select the commit you want to view.
+
+The interface now shows the repository as it existed at that commit.
+
+### Open a branch, commit, or tag
+
+By default, the code search and source browsing interface opens a repository to
+the master branch.  To open a different branch, from the Breadcrumb toolbar,
+click the **Branch/Commit/Tag** menu. A submenu opens, allowing you to select a
+branch using a branch name, a tag name, or through a search box.
+
+*  To select a branch using a branch name, select **Branch** and then click the
+   name of the branch.
+*  To select a branch using a tag name, select **Tag** and
+   then click the tag name.
+*  To select a branch using a commit id, select **Commit** and then click the
+   commit id.
+*  To search for a branch, commit, or tag, select the corresponding item and
+   type a search term in the search box.
+
+## Working with files
+
+When you select a repository from the main screen, the screen changes to display
+a view of that repository. If a README file exists, its contents appear in the
+file pane, located on the right side of the screen. Otherwise, a list of
+repository's files and folders appear.  On the left side of the screen is a tree
+view of the repository's files and folders. You can use this tree to browse and
+open specific files.
+
+Notice that, when you are viewing a repository, the Breadcrumb toolbar now has
+three components:
+
+*  A **Repository** menu, from which you can select different repositories
+*  A **Branch/Commit/Tag** menu, from which you can select specific branches,
+   tags, or commits
+*  A **File path** box, which displays the name of the current file or folder
+   and its corresponding path
+
+### Open a file
+
+You can open a file by browsing to its directory and selecting it. The view of
+the repository updates to show the contents of the file in the file pane, and
+its location in the repository in the tree pane.
+
+### View file changes
+
+To view file changes:
+
+1. From the view of the repository, select the file.
+1. Click **BLAME**, located in the upper-right corner.
+
+The file pane updates to display who made changes to the file and when.
+
+### View change history
+
+To view the change history of a file:
+
+1.  From the view of the repository, select the file.
+1.  Click **HISTORY**, located in the upper-right corner.
+    The **Change history** pane appears, showing the commits for this file.
+
+### View code reviews
+
+For Gerrit code reviews, you can open the tool directly from the Change History pane.
+
+To view the code review for a file:
+
+1. From the view of the repository, select the file.
+1. Click **HISTORY**, located in the upper-right corner. The Change History pane
+   appears, showing the commits for this file.
+1. Hover over a commit. A **More** button (three vertical dots) appears.
+1. Click the **More** button.
+1. Select **View code review**.
+
+The Gerrit Code Review tool opens in a new browser window.
+
+### Open a file at a specific commit
+
+To open a file at a specific commit:
+
+1. From the view of the repository, select the file.
+1. Click **HISTORY**, located in the upper-right corner. The Change History pane
+   appears, showing the commits for this file.
+1. Hover over a commit. A **VIEW** button appears.
+1. Click the **VIEW** button.
+
+### Compare a file to a different commit
+
+To compare a file at a different commit:
+
+1. From the view of the repository, select the file. To compare from two
+   different commits, first open the file at that commit.
+1. Hover over a commit. A **DIFF** button appears.
+1. Click the **DIFF** button.
+
+The file pane updates to display a side-by-side comparison between the two
+files. The oldest of the two commits is always on the left.
+
+In the Change History pane, both commits are highlighted, and a label indicates
+if the commit is displayed on the left or the right.
+
+To change either file, hover over the commit in the Change History pane. Then,
+click either the **Left** or **Right** button to have the open the commit on the
+left or right side of the diff.
+
+## Searching for code
+
+You can search for specific files or code snippets using the search box located
+at the top of the screen. Searches are always against the master branch.
+
+All searches use [RE2 regular expressions](https://github.com/google/re2/wiki/Syntax)
+by default. If you do not want to use regular expressions, enclose your search
+in double quotes ( " ).
+
+**Note:** To quickly search for a specific file, either add a backslash in front
+of the period, or enclose the entire file name in quotes.
+
+```
+foo\.java
+"foo.java"
+```
+
+You can refine your search using the following filters.
+
+<table border="1px">
+<thead>
+<tr>
+<th style="padding:5px"><strong>Filter</strong></th>
+<th style="padding:5px"><strong>Other options</strong></th>
+<th style="padding:5px"><strong>Description</strong></th>
+<th style="padding:5px"><strong>Example</strong></th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td style="padding:5px">lang:</td>
+<td style="padding:5px">language:</td>
+<td style="padding:5px">Perform an exact match by file language.</td>
+<td style="padding:5px">lang:java test</td>
+</tr>
+<tr>
+<td style="padding:5px">file:</td>
+<td style="padding:5px">filepath:<br>
+path:<br>
+f:</td>
+<td style="padding:5px"></td>
+<td style="padding:5px"></td>
+</tr>
+<tr>
+<td style="padding:5px">case:yes</td>
+<td style="padding:5px"></td>
+<td style="padding:5px">Make the search case sensitive. By default, searches are not case-sensitive.</td>
+<td style="padding:5px">case:yes Hello World</td>
+</tr>
+<tr>
+<td style="padding:5px">class:</td>
+<td style="padding:5px"></td>
+<td style="padding:5px">Search for a class name.</td>
+<td style="padding:5px">class:MainClass</td>
+</tr>
+<tr>
+<td style="padding:5px">function:</td>
+<td style="padding:5px">func:</td>
+<td style="padding:5px">Search for a function name.</td>
+<td style="padding:5px">function:print</td>
+</tr>
+<tr>
+<td style="padding:5px">-</td>
+<td style="padding:5px"></td>
+<td style="padding:5px">Negates the term from the search.</td>
+<td style="padding:5px">hello -world</td>
+</tr>
+<tr>
+<td style="padding:5px">\</td>
+<td style="padding:5px"></td>
+<td style="padding:5px">Escapes special characters, such as ., \, or (.</td>
+<td style="padding:5px">run\(\)</td>
+</tr>
+<tr>
+<td style="padding:5px">"[term]"</td>
+<td style="padding:5px"></td>
+<td style="padding:5px">Perform a literal search.</td>
+<td style="padding:5px">"class:main"</td>
+</tr>
+</tbody>
+</table>
+
+# Additional Support
+
+To report an issue, click the **Feedback** button that appears in the top right-hand corner of the screen and enter your feedback in the provided form.

--- a/browse-and-search-user-guide.md
+++ b/browse-and-search-user-guide.md
@@ -183,6 +183,9 @@ To make cross references easier to identify, click **Cross References**,
 located in the upper-right corner. This option displays an underline below all
 cross references in a file.
 
+**Note:** If **Cross References** is grayed out, it indicates that
+cross references are not available for that file.
+
 Click a cross reference to open the Cross Reference pane. This pane contains
 two sections:
 

--- a/contribute.html
+++ b/contribute.html
@@ -1,0 +1,61 @@
+---
+nav: contribute
+---
+
+<!DOCTYPE html>
+<html lang="en" itemscope itemtype="https://schema.org/WebPage">
+  {% include head.html %}
+  <body>
+    {% include header.html %}
+
+    <div class="page-title-bar">
+      <div class="container">
+        <h1>Contribute</h1>
+      </div>
+    </div>
+
+    <div class="container vpad">
+      <div class="row">
+        <div class="col-lg-3">
+          <a class="btn btn-default btn-lg btn-block sidebar-toggle"
+              data-toggle="collapse" href="#sidebar-nav" aria-expanded="false"
+              aria-controls="sidebar-nav">
+            <i class="glyphicon glyphicon-menu-hamburger"></i> Navigation
+          </a>
+          <nav class="sidebar collapse" id="sidebar-nav">
+            <ul class="sidebar-nav">
+              <li><a href="/contributing.html">Contributing to Bazel</a></li>
+              <li><a href="https://github.com/bazelbuild/bazel/wiki/Bazel-Users">Who's Using Bazel</a></li>
+              <li><a href="/roadmap.html">Roadmap</a></li>
+              <li><a href="/governance.html">Governance</a></li>
+              <li><a href="/naming.html">Naming Bazel projects</a></li>
+            </ul>
+            <h3>Technical Docs</h3>
+            <ul class="sidebar-nav">
+              <li><a href="/designs/skyframe.html">Skyframe</a></li>
+              <li><a href="/designs/index.html">Design Documents</a></li>
+              <li><a href="/windows-chocolatey-maintenance.html">Maintaining Bazel Chocolatey package on Windows</a></li>
+            </ul>
+            <h3>External Resources</h3>
+            <ul class="sidebar-nav">
+              <li><a href="https://github.com/bazelbuild/bazel">GitHub</a></li>
+              <li><a href="https://source.bazel.build/">Search Bazel code</a>
+                <ul class="sidebar-nav">
+                  <li><a href="/browse-and-search-user-guide.html">Search user guide<li>
+                </ul>
+              </li>
+              <li><a href="https://groups.google.com/forum/#!forum/bazel-dev">Developer mailing list</a></li>
+              <li><a href="https://bazel-review.googlesource.com">Gerrit</a></li>
+              <li><a href="irc://irc.freenode.net/bazel">IRC</a><li>
+            </ul>
+          </nav>
+        </div>
+        <div class="col-lg-9">
+          {{ content }}
+        </div>
+      </div>
+    </div>
+
+    {% include footer.html %}
+  </body>
+</html>


### PR DESCRIPTION
Pull request #85 was supposed to handle this, but apparently I updated the wrong contribute.html file.