### PR TITLE
Change link to StackOverflow to an absolute instead of relative one

### DIFF
--- a/faq.md
+++ b/faq.md
@@ -4,7 +4,7 @@ title: FAQ
 nav: faq
 ---
 
-Ask technical questions [on StackOverflow using the 'bazel' tag](stackoverflow.com/questions/tagged/bazel).
+Ask technical questions [on StackOverflow using the 'bazel' tag](https://stackoverflow.com/questions/tagged/bazel).
 
 What is Bazel?
 --------------


### PR DESCRIPTION
In the FAQ-Section (https://bazel.build/faq.html) the Stack Overflow link points to https://bazel.build/stackoverflow.com/questions/tagged/bazel. This link leads to a 404 - Page not found.

This commit changes the link to https://stackoverflow.com/questions/tagged/bazel