### PR TITLE
Add blank line before code sections

### DIFF
--- a/contributing.md
+++ b/contributing.md
@@ -70,15 +70,19 @@ for Java. We don't have IDE support for other languages in Bazel right now.
    *  `git clone https://bazel.googlesource.com/bazel`
 *  Try to build Bazel:
    *  On Linux/macOS, in Bash/Terminal:
+
       ```
       cd bazel
       bazel build //src:bazel
       ```
+
    *  On Windows, in the Command Prompt:
+
       ```
       cd bazel
       bazel --output_user_root=c:\tmp build //src:bazel.exe
       ```
+
 *  This will produce a working Bazel binary in `bazel-bin/src/bazel` (or `bazel-bin/src/bazel.exe` on Windows).
 
 If everything works fine, feel free to configure your favorite IDE in the


### PR DESCRIPTION
Fix the wrong layout of commands.
https://bazel.build/contributing.html