### PR TITLE
update contribution guidelines

### DIFF
--- a/contributing.md
+++ b/contributing.md
@@ -25,25 +25,7 @@ a lot of time in a patch. Meet other Bazel contributors on [IRC](http://webchat.
 2. Discuss your plan and design, and get agreement on our [mailing list](https://groups.google.com/forum/#!forum/bazel-dev).
 3.  Prepare a git commit that implements the feature. Don't forget to add tests.
 4.  Ensure you've signed a [Contributor License Agreement](https://cla.developers.google.com).
-5.  Create a new code review. You can use a GitHub pull request, or a code
-    review on [Gerrit](https://bazel-review.googlesource.com).
-    *  To use GitHub, send a pull request. If you're new to GitHub, read [about
-       pull requests](https://help.github.com/articles/about-pull-requests/).
-    *  To use Gerrit, you must:
-       *  Have an automatically generated "Change Id" line in your commit
-          message. If you haven't used Gerrit before, it will print a bash
-          command to create the git hook and then you will need to run
-          `git commit --amend` to add the line.
-       *  To create a code review on Gerrit, run:
-
-          ```
-          git push https://bazel.googlesource.com/bazel HEAD:refs/for/master
-          ```
-
-          The HTTP password required by Gerrit can be obtained from your
-          [Gerrit settings page](https://bazel-review.googlesource.com/#/settings/http-password).
-          See the [Gerrit documentation](https://gerrit-review.googlesource.com/Documentation/user-upload.html)
-          for more information about uploading changes.
+5.  Send us a pull request on GitHub. If you're new to GitHub, read [about pull requests](https://help.github.com/articles/about-pull-requests/).
 6.  Wait for a Bazel team member to assign you a reviewer.
     It should be done in 2 business days (excluding holidays in the USA and
     Germany). If you do not get a reviewer within that time frame, you can ask
@@ -54,20 +36,20 @@ a lot of time in a patch. Meet other Bazel contributors on [IRC](http://webchat.
     changes to your patch.
 8.  An engineer at Google applies the patch to our internal version control
     system. The patch is exported as a Git commit, at which point the GitHub
-    or Gerrit code review is closed.
+    pull request is closed.
 
 ## Setting up your coding environment
 
-For now we have support for IntelliJ, and partial support for the Eclipse IDE
-for Java. We don't have IDE support for other languages in Bazel right now.
+For now we have support for IntelliJ. We don't have IDE support for other
+languages in Bazel right now.
 
 ### Preparations
 
 *  [Install Bazel](https://bazel.build/versions/master/docs/install.html) on your
    system. Note that for developing Bazel, you need the latest released version
    of Bazel.
-*  Clone Bazel's Git repository from Gerrit:
-   *  `git clone https://bazel.googlesource.com/bazel`
+*  Clone Bazel's Git repository from GitHub:
+   *  `git clone https://github.com/bazelbuild/bazel`
 *  Try to build Bazel:
    *  On Linux/macOS, in Bash/Terminal:
 
@@ -85,9 +67,6 @@ for Java. We don't have IDE support for other languages in Bazel right now.
 
 *  This will produce a working Bazel binary in `bazel-bin/src/bazel` (or `bazel-bin/src/bazel.exe` on Windows).
 
-If everything works fine, feel free to configure your favorite IDE in the
-following steps.
-
 ### Creating an IntelliJ project
 
 To work with IntelliJ:
@@ -103,21 +82,6 @@ To work with IntelliJ:
 *  Download [Google's Java Code Style Scheme file for IntelliJ](https://github.com/google/styleguide/blob/gh-pages/intellij-java-google-style.xml),
    import it (go to `Preferences` > `Editor` > `Code Style` > `Java`, click `Manage`, then `Import`)
    and use it when working on Bazel's code.
-
-### Creating an Eclipse project
-
-To work with Eclipse:
-
-*  [Install Bazel](https://bazel.build/versions/master/docs/install.html) on your system.
-*  Clone Bazel's Git repository from Gerrit:
-   *  `git clone https://bazel.googlesource.com/bazel`
-*  Install the [e4b](https://github.com/bazelbuild/e4b) plugin.
-*  Change the path to the Bazel binary in the plugin preferences.
-*  Import the Bazel workspace as a Bazel project (`File` > `New` > `Other` >
-   `Import Bazel Workspace`).
-*  Select `src > main > java` and `src > test > java` as directories and add
-   `//src/main/java/...` and `//src/test/java/...` as targets.
-*  Download [Google's Java Code Style Scheme file for Eclipse](https://github.com/google/styleguide/blob/gh-pages/eclipse-java-google-style.xml) and use it when working on Bazel's code.
 
 <a name="compile-bazel"></a>
 ### Compiling Bazel
@@ -166,9 +130,7 @@ But if you want to debug the Java code, you must attach to the server using the 
 *  Run Bazel with debugging option `--host_jvm_debug` before the
    command (e.g., `bazel --host_jvm_debug build //src:bazel`).
 *  Attach a debugger to the port 5005. With `jdb` for instance,
-   run `jdb -attach localhost:5005`. From within Eclipse, use the
-   [remote Java application launch
-   configuration](http://help.eclipse.org/luna/index.jsp?topic=%2Forg.eclipse.jdt.doc.user%2Ftasks%2Ftask-remotejava_launch_config.htm).
+   run `jdb -attach localhost:5005`.
 *  Our IntelliJ plugin has built-in
   [debugging support](https://ij.bazel.build/docs/run-configurations.html)
 


### PR DESCRIPTION
- remove gerrit as an accepted way to send patches.
- remove the eclipse plugin, which is mostly unmaintained.