### PR TITLE
remove sidebar link to Gerrit

### DIFF
--- a/_layouts/contribute.html
+++ b/_layouts/contribute.html
@@ -47,7 +47,6 @@ nav: contribute
               <li><a href="https://source.bazel.build/">Search Bazel code</a></li>
               <li><a href="/browse-and-search-user-guide.html">Search user guide</a></li>
               <li><a href="https://groups.google.com/forum/#!forum/bazel-dev">Developer mailing list</a></li>
-              <li><a href="https://bazel-review.googlesource.com">Gerrit</a></li>
               <li><a href="irc://irc.freenode.net/bazel">IRC</a><li>
             </ul>
           </nav>


### PR DESCRIPTION
We mostly use Gerrit for our Buildkite presubmit, which
is not a useful resource for users.