### PR TITLE
Remove Roadmap seciton in the menu

### DIFF
--- a/_layouts/contribute.html
+++ b/_layouts/contribute.html
@@ -27,15 +27,8 @@ nav: contribute
               <li><a href="/contributing.html">Contributing to Bazel</a></li>
               <li><a href="https://github.com/bazelbuild/bazel/wiki/Bazel-Users">Who's Using Bazel</a></li>
               <li><a href="/governance.html">Governance</a></li>
+              <li><a href="/roadmap.html">Roadmap</a></li>
               <li><a href="/naming.html">Naming Bazel projects</a></li>
-            </ul>
-            <h3>Roadmaps</h3>
-            <ul class="sidebar-nav">
-              <li><a href="/roadmap.html">Bazel General Roadmap</a></li>
-	      <li><a href="/roadmaps/configuration.html">Configurability Roadmap</a></li>
-	      <li><a href="/roadmaps/external-deps.html">External Dependencies Roadmap</a></li>
-	      <li><a href="/roadmaps/skylark.html">Skylark</a></li>
-              <li><a href="/roadmaps/windows.html">Windows Roadmap</a></li>
             </ul>
             <h3>Technical Docs</h3>
             <ul class="sidebar-nav">


### PR DESCRIPTION
Users should first read about the general roadmap before going to the
subsections. Also, the menu was getting long (and it still doesn't
contain all the roadmaps).