### PR TITLE
Update governance plan documentation

### DIFF
--- a/governance.md
+++ b/governance.md
@@ -20,37 +20,33 @@ Please also see our [contribution guidelines](contributing.html).
 We use the following rules for accepting code contributions. This is written from the perspective
 that there is a group of people who cooperatively support the project (the *core contributors*). In
 contrast, external contributors are not actively supporting the project, but just contributing
-individual changes. At this time, all core contributors work for Google (see below for the full
-list), but this will hopefully change over time.
+individual changes. At this time, all core contributors work for Google, but this will hopefully
+change over time.
 
 1. We require all contributors to sign [Google's Contributor License
    Agreement](https://cla.developers.google.com/).
 
-2. We accept well-written, well-tested contributions of rules written in
-   [Skylark](docs/skylark/concepts.html), in a `contrib/` directory or similar with clearly documented
-   support policies.
+1. We accept well-written, well-tested bug fixes to built-in rules.
 
-3. We accept well-written, well-tested bug fixes to built-in rules.
-
-4. We accept well-written, well-tested feature contributions if a core contributor assumes support
+1. We accept well-written, well-tested feature contributions if a core contributor assumes support
    responsibilities, i.e., readily answers support questions and works on bugs. This includes
    feature contributions from external contributors. If there is no core contributor to support a
    feature, then we will deprecate and subsequently delete the feature - we will give three months'
    notice in such cases.
 
-5. We will not accept untested changes, except in very rare cases.
+1. We will not accept untested changes, except in very rare cases.
 
-6. We require a pre-commit code review from a core contributor for all changes. For the time being,
+1. We require a pre-commit code review from a core contributor for all changes. For the time being,
    we will have to continue making changes across the internal and external code bases, which will
    be reviewed internal to Google.
 
-7. We will roll back changes if they break the internal development processes of any of the core
+1. We will roll back changes if they break the internal development processes of any of the core
    contributors.
 
-8. We will move towards an open governance model where multiple parties have commit access,
+1. We will move towards an open governance model where multiple parties have commit access,
    roll-back rights, and can provide explicit support for features or rules.
 
-9. We will work with interested parties to improve existing extension points and to establish new
+1. We will work with interested parties to improve existing extension points and to establish new
     extension points if they do not run counter to the internal requirements of any of the core
     contributors.
 


### PR DESCRIPTION
Couple of changes:

- Remove reference to core contributor list, since it's removed and replaced with the contact email to bazel-core@
- Remove rule about accepting Starlark rules into contrib/, since we're moving away from hosting rules in core Bazel, and we don't have a contrib/ directory.