### PR TITLE
Switch redcarpet to kramdown

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -1,7 +1,11 @@
 destination: production
-markdown: redcarpet
+markdown: kramdown
+kramdown:
+  syntax_highlighter: rouge
+  toc_levels: "2,3"
+highlighter: rouge
+
 paginate: 10
-highlighter: pygments
 sass:
   sass_dir: _sass
 gems: [jekyll-paginate]


### PR DESCRIPTION
Following the doc site's switch in https://github.com/bazelbuild/bazel/commit/9ed63798e31541c4036ad2a4f3ffaf07c0171406