### PR TITLE
(all roadmaps) update broken links after update to Kramdown

### DIFF
--- a/roadmaps/coverage.md
+++ b/roadmaps/coverage.md
@@ -23,8 +23,7 @@ title: Bazel Code Coverage Roadmap
 
 # Bazel Code Coverage Roadmap 2018
 
-*Last verified: 2018-08-08* ([update history]
-(https://github.com/bazelbuild/bazel-website/commits/master/roadmaps/coverage.md))
+*Last verified: 2018-08-08* ([update history](https://github.com/bazelbuild/bazel-website/commits/master/roadmaps/coverage.md))
 
 ## Fast Bazel C++ coverage ([tracking issue](https://github.com/bazelbuild/bazel/issues/5882)) (P0)
 

--- a/roadmaps/cpp.md
+++ b/roadmaps/cpp.md
@@ -23,8 +23,7 @@ title: Bazel C++ Rules Roadmap
 
 # Bazel C++ Rules Roadmap
 
-*Last verified: 2018-08-08* ([update history]
-(https://github.com/bazelbuild/bazel-website/commits/master/roadmaps/cpp.md))
+*Last verified: 2018-08-08* ([update history](https://github.com/bazelbuild/bazel-website/commits/master/roadmaps/cpp.md))
 
 ## Skylark API for the C++ toolchain (2018/Q3)
 

--- a/roadmaps/platforms.md
+++ b/roadmaps/platforms.md
@@ -23,8 +23,7 @@ title: Bazel Platforms Roadmap
 
 # Bazel Platforms Roadmap
 
-*Last verified: 2018-10-19* ([update history]
-(https://github.com/bazelbuild/bazel-website/commits/master/roadmaps/platforms.md))
+*Last verified: 2018-10-19* ([update history](https://github.com/bazelbuild/bazel-website/commits/master/roadmaps/platforms.md))
 
 *Point of contact:* [katre](https://github.com/katre)
 


### PR DESCRIPTION
Context: https://groups.google.com/forum/#!searchin/bazel-dev/jekyll%7Csort:date/bazel-dev/puQn4173CXU/pjxr213RAQAJ