### PR TITLE
Maintainers' Guide: add sections on issues to be routed

### DIFF
--- a/maintainers-guide.md
+++ b/maintainers-guide.md
@@ -124,7 +124,7 @@ Routed issues **must have**:
 1. a `team` label, e.g. `team-Starlark`
 2. either the `untriaged` label OR one priority label (`p0`, `p1`, `p2`, `p3`, `p4`), but not both.
 
-The exception to this are issues for tracking releases and incompatible changes.
+The exceptions to this are issues for tracking releases and incompatible changes.
 
 See the list of issues to be routed
 [here](https://github.com/bazelbuild/bazel/issues?utf8=%E2%9C%93&q=is%3Aissue+is%3Aopen+-label%3Ap1+-label%3Ap2+-label%3Ap3+-label%3Ap4+-label%3Auntriaged+-label%3Ap0+-label%3Arelease+-label%3Aincompatible-change).

--- a/maintainers-guide.md
+++ b/maintainers-guide.md
@@ -122,7 +122,7 @@ and PRs on weekly rotation basis. The subteam can be reached on GitHub using the
 Routed issues **must have**:
 
 1. a `team` label, e.g. `team-Starlark`
-2. an `untriaged` label OR a `priority` label.
+2. either the `untriaged` label OR one priority label (`p0`, `p1`, `p2`, `p3`, `p4`), but not both.
 
 The exception to this are issues for tracking releases and incompatible changes.
 

--- a/maintainers-guide.md
+++ b/maintainers-guide.md
@@ -119,6 +119,16 @@ The Developer Experience (DevEx) subteam handles the initial routing of issues
 and PRs on weekly rotation basis. The subteam can be reached on GitHub using the
 `@bazelbuild/devex` alias.
 
+Routed issues **must have**:
+
+1. a `team` label, e.g. `team-Starlark`
+2. an `untriaged` label OR a `priority` label.
+
+The exception to this are issues for tracking releases and incompatible changes.
+
+See the list of issues that need to be routed
+[here](https://github.com/bazelbuild/bazel/issues?utf8=%E2%9C%93&q=is%3Aissue+is%3Aopen+-label%3Ap1+-label%3Ap2+-label%3Ap3+-label%3Ap4+-label%3Auntriaged+-label%3Ap0+-label%3Arelease+-label%3Aincompatible-change).
+
 ## My team owns a label. What should I do?
 
 Subteams need to triage all issues in the [labels they own](#team-labels),

--- a/maintainers-guide.md
+++ b/maintainers-guide.md
@@ -126,7 +126,7 @@ Routed issues **must have**:
 
 The exception to this are issues for tracking releases and incompatible changes.
 
-See the list of issues that need to be routed
+See the list of issues to be routed
 [here](https://github.com/bazelbuild/bazel/issues?utf8=%E2%9C%93&q=is%3Aissue+is%3Aopen+-label%3Ap1+-label%3Ap2+-label%3Ap3+-label%3Ap4+-label%3Auntriaged+-label%3Ap0+-label%3Arelease+-label%3Aincompatible-change).
 
 ## My team owns a label. What should I do?


### PR DESCRIPTION
Adding a section on what it means for an issue to be routed, and a list of issues to be routed.