### PR TITLE
Fix broken formatting with the Slack link in the navigation

### DIFF
--- a/_layouts/contribute.html
+++ b/_layouts/contribute.html
@@ -43,7 +43,7 @@ nav: contribute
               <li><a href="https://source.bazel.build/">Search Bazel code</a></li>
               <li><a href="/browse-and-search-user-guide.html">Search user guide</a></li>
               <li><a href="https://groups.google.com/forum/#!forum/bazel-dev">Developer mailing list</a></li>
-              <li><a href="https://bazelbuild.slack.com">Slack</a> (get an <a href="https://join.slack.com/t/bazelbuild/shared_invite/enQtNDYyODAxNDY4MjQxLWU1OTBjOWJjOTA1MmE5YjIwMTM5MjFhZGMwM2YzYTEzYTdhNGIzMTFiZjI1NTlhYTkzNGQ5MjBkYzE5YjMyMTE">invite</a>)</li>
+              <li><a style="display: inline;" href="https://bazelbuild.slack.com">Slack</a> (get an <a style="display: inline;" href="https://join.slack.com/t/bazelbuild/shared_invite/enQtNDYyODAxNDY4MjQxLWU1OTBjOWJjOTA1MmE5YjIwMTM5MjFhZGMwM2YzYTEzYTdhNGIzMTFiZjI1NTlhYTkzNGQ5MjBkYzE5YjMyMTE">invite</a>)</li>
             </ul>
           </nav>
         </div>


### PR DESCRIPTION
Currently, each anchor element is displayed as a block. For the Slack and invite link to be on the same line, we force the anchors to be inline instead.