### PR TITLE
Rename Skylark to Starlark. Remove information about IRC.

### DIFF
--- a/contributing.md
+++ b/contributing.md
@@ -152,16 +152,15 @@ Bazel is organized in several parts:
    *  Core code which is mostly composed of [SkyFrame](designs/skyframe.html) and some
      utilities.
    *  Rules written in Bazel's extension language
-     [Skylark](docs/skylark/index.html) are defined in `tools/build_rules`. If
-     you want to add rules, consider using [Skylark](docs/skylark/index.html)
-     first.
+     [Starlark](docs/skylark/index.html) are defined in `tools/build_rules`. If
+     you want to add rules, use [Starlark](docs/skylark/index.html).
    *  Builtin rules in `com.google.devtools.build.lib.rules` and in
      `com.google.devtools.build.lib.bazel.rules`. You might want to read about
      the [Challenges of Writing Rules](docs/rule-challenges.html) first.
 *  Java native interfaces in `src/main/native`.
 *  Various tooling for language support (see the list in the
    [compiling Bazel](#compile-bazel) section).
-   
+
 ## Searching Bazel's source code
 
 To quickly search through Bazel's source code, use [Bazel Code Search](https://source.bazel.build/). You can navigate Bazel's repositories, branches, and files. You can also view history, diffs, and blame information. To learn more, see the

--- a/roadmaps/cpp.md
+++ b/roadmaps/cpp.md
@@ -25,12 +25,12 @@ title: Bazel C++ Rules Roadmap
 
 *Last verified: 2018-08-08* ([update history](https://github.com/bazelbuild/bazel-website/commits/master/roadmaps/cpp.md))
 
-## Skylark API for the C++ toolchain (2018/Q3)
+## Starlark API for the C++ toolchain (2018/Q3)
 
 Status: <span class="donestatus">DONE</span>
 
 Objective: It's possible to obtain the exact command line as C++ actions would
-use from Skylark ([tracking
+use from Starlark ([tracking
 issue](https://github.com/bazelbuild/bazel/issues/4571), [design
 doc](https://docs.google.com/document/d/1g91BWJITcYw_X-VxsDC0VgUn5E9g0kRBGoBSpoO41gA/edit), owner:
 [mhlopko](https://github.com/mhlopko)).
@@ -48,8 +48,8 @@ owner: [mhlopko](https://github.com/mhlopko)).
 
 Status: <span class="inprogressstatus">IN PROGRESS</span>
 
-Objective: It's possible to write a custom skylark rule that can depend on C++
-rules, and C++ rules can depend on skylark (C++ sandwich)
+Objective: It's possible to write a custom Starlark rule that can depend on C++
+rules, and C++ rules can depend on Starlark (C++ sandwich)
 ([tracking issue](https://github.com/bazelbuild/bazel/issues/4570),
 owner: [oquenchil](https://github.com/oquenchil)).
 
@@ -61,11 +61,11 @@ Status: <span class="inprogressstatus">IN PROGRESS</span>
 Objective: Features are the only way of defining crosstool flags
 (owner: [mhlopko](https://github.com/mhlopko)).
 
-## Crosstool in Skylark (2018/Q3)
+## Crosstool in Starlark (2018/Q3)
 
 Status: <span class="inprogressstatus">IN PROGRESS</span>
 
-Objective: Crosstool can be written in Skylark 
+Objective: Crosstool can be written in Starlark 
 ([design doc](https://docs.google.com/document/d/1Nqf16jqDGWSrPp4VuRxh0iNnVBoAXsO0meDH69J9xoc/edit#heading=h.r30au8wdo4dh),
 [tracking issue](https://github.com/bazelbuild/bazel/issues/5380),
 owner: [scentini](https://github.com/scentini)).

--- a/roadmaps/starlark.md
+++ b/roadmaps/starlark.md
@@ -6,7 +6,7 @@ title: Starlark roadmap
 # Starlark Roadmap
 
 *Last verified: 2018-07-18*
-([update history](https://github.com/bazelbuild/bazel-website/commits/master/roadmaps/skylark.md))
+([update history](https://github.com/bazelbuild/bazel-website/commits/master/roadmaps/starlark.md))
 
 *Point of contact:* [laurentlb](https://github.com/laurentlb)
 

--- a/support.md
+++ b/support.md
@@ -11,8 +11,6 @@ title: Get Support
 * Report bugs or feature requests in our [GitHub issue tracker](https://github.com/bazelbuild/bazel/issues).
 * Find other Bazel contributors on [Slack](https://bazelbuild.slack.com) (get an [invite
 here](https://join.slack.com/t/bazelbuild/shared_invite/enqtndyyodaxndy4mjqxlwu1otbjowjjota1mme5yjiwmtm5mjfhzgmwm2yzytezytdhngizmtfizji1ntlhytkzngq5mjbkyze5yjmymte)).
-* You might also find some team members on the [IRC
-channel](http://webchat.freenode.net) (irc.freenode.net#bazel).
 
 # Support Policy
 
@@ -40,10 +38,6 @@ details, just ask on [bazel-discuss](https://groups.google.com/forum/#!forum/baz
 All undocumented features (attributes, rules, "Make" variables, and flags) are subject to change
 at any time without prior notice. Features that are documented but marked *experimental* are also
 subject to change at any time without prior notice.
-
-Bazel's extension language Skylark (anything you write in a `.bzl` file) is still subject to change.
-We are in the process of migrating Google to Skylark, and expect the language part to extend macros
-to stabilize as part of that process. Adding rules with skylark is still somewhat experimental.
 
 Help keep us honest: report bugs and regressions in the
 [GitHub bugtracker](https://github.com/bazelbuild/bazel/issues). We will make an effort to triage all
@@ -114,13 +108,14 @@ version number of the form MAJOR.MINOR.PATCH according to the
 
 ## Current Status
 
-### Built-In Rules and the Internal API For Rules ###
+### Built-In Rules and the Internal API For Rules
+
 We are planning a number of changes to the APIs between the core of Bazel and the built-in rules,
 in order to make it easier for us to develop openly. This has the added benefit of also making it
-easier for users to maintain their own rules (if written in Java instead of Skylark), if they don't
+easier for users to maintain their own rules (if written in Java instead of Starlark), if they don't
 want to or cannot check this code into our repository. However, it also means our internal API is
-not stable yet. In the long term, we want to move to Skylark wholesale, so we encourage contributors
-to use Skylark instead of Java when writing new rules. Rewriting all of our built-in rules is going
+not stable yet. In the long term, we want to move to Starlark wholesale, so we ask contributors
+to use Starlark instead of Java when writing new rules. Rewriting all of our built-in rules is going
 to be a lengthy process however.
 
 1. We will fix the friction points that we know about, as well as those that we discover every time
@@ -141,8 +136,6 @@ to be a lengthy process however.
 7. We will move more of our rule implementations into the open source repository (Android, Go,
    Python, the remaining C++ rules), even if we don't consider the code to be *ready* or if they are
    still missing tools to work properly.
-8. In order to be able to accept external contributions, our highest priority item for Skylark is a
-   testing framework. We encourage to write new rules in Skylark rather than in Java.
 
 
 ### Stable


### PR DESCRIPTION
We don't monitor IRC. Slack is much more active.