### PR TITLE
Shorten release baking period to 1 week

### DIFF
--- a/support.md
+++ b/support.md
@@ -58,10 +58,10 @@ projects tested on [ci.bazel.io](http://ci.bazel.io).
 We announce those release candidates on [bazel-discuss](https://groups.google.com/forum/#!forum/bazel-discuss).
 Over the next days, we monitor community bug reports for regressions in release candidate.
 
-If no regressions are discovered, we officially release the candidate after two weeks. However,
+If no regressions are discovered, we officially release the candidate after one week. However,
 regressions can delay the release of a release candidate. If regressions are found, we apply
 corresponding cherry-picks to the release candidate to fix those regressions. If no further
-regressions are found for two business days, but not before two week has elapsed since the first
+regressions are found for two business days, but not before one week has elapsed since the first
 release candidate, we release it.
 
 After a release candidate is cut, we do not cherry-pick new features into it.


### PR DESCRIPTION
The original policy was created in times when [incompatible changes policy](https://docs.bazel.build/versions/master/backward-compatibility.html) didn't exist. With the policy in place, and Bazel Green team monitoring [the downstream pipeline](https://buildkite.com/bazel/bazel-at-head-plus-downstream) on the Bazel CI, and continuously adding more projects to the downstream pipeline, I believe we discover fewer regressions in Bazel release candidates then before.

On the other hand, we could use more time for users who want to test incompatible flags that are in their migration window and give feedback to the flag owner. Currently it happens that there are just few days between a release candidate is released and before next one is cut.

This change is an experiment to see if shorter baking period will result in faster releases, more time to give feedback on incompatible changes, while not regressing on the number of patch releases.