### PR TITLE
Clarify how to write relnotes

### DIFF
--- a/breaking-changes-guide.md
+++ b/breaking-changes-guide.md
@@ -91,9 +91,9 @@ Before flipping the default value of the flag to true, please make sure that:
 
 When changing the flag default to true, please:
 
-  * Use [`RELNOTES[INC]:`](release-notes.html) in the commit description, with the
+  * Use `RELNOTES[INC]` in the commit description, with the
     following format:
-    `--incompatible_name_of_flag is flipped to true. See #yxz for details`
+    `RELNOTES[INC]: --incompatible_name_of_flag is flipped to true. See #yxz for details`
     You can include additional information in the rest of the commit description.
   * Use `Fixes #xyz` in the description, so that the GitHub issue gets closed
     when the commit is merged.

--- a/breaking-changes-guide.md
+++ b/breaking-changes-guide.md
@@ -59,8 +59,8 @@ should contain the URL of the GitHub issue. As the flag name starts with
       },
 ```
 
-In the commit description, use [`RELNOTES:`](release-notes.html) followed by a short description, the
-name of the flag, and a link to the GitHub issue.
+In the commit description, add a brief summary of the flag. 
+Also add [`RELNOTES:`](release-notes.html) in the following form: `RELNOTES: --incompatible_name_of_flag has been added. See #yxz for details`
 
 
 ## Labels
@@ -91,8 +91,10 @@ Before flipping the default value of the flag to true, please make sure that:
 
 When changing the flag default to true, please:
 
-  * Use [`RELNOTES:`](release-notes.html) in the commit description, with the
-    name the of the flag.
+  * Use [`RELNOTES[INC]:`](release-notes.html) in the commit description, with the
+    following format:
+    `--incompatible_name_of_flag is flipped to true. See #yxz for details`
+    You can include additional information in the rest of the commit description.
   * Use `Fixes #xyz` in the description, so that the GitHub issue gets closed
     when the commit is merged.
 


### PR DESCRIPTION
The automatic release notes generator does take into account the [INC] tag, so it should be used when the flag is actually flipped. Additionally, it is really helpful to the release manager if the RELNOTES themselves contain the name of the flag, what happened with the flag (added vs flipped), and the link to the github issue directly in the RELNOTES (as opposed to just in the commit description). Otherwise the RM has to search for keywords to find the actual github issue.