### PR TITLE
Fix Slack invite link

### DIFF
--- a/_layouts/contribute.html
+++ b/_layouts/contribute.html
@@ -47,7 +47,7 @@ nav: contribute
               <li><a href="https://source.bazel.build/">Search Bazel code</a></li>
               <li><a href="/browse-and-search-user-guide.html">Search user guide</a></li>
               <li><a href="https://groups.google.com/forum/#!forum/bazel-dev">Developer mailing list</a></li>
-              <li><a style="display: inline;" href="https://bazelbuild.slack.com">Slack</a> (get an <a style="display: inline;" href="https://join.slack.com/t/bazelbuild/shared_invite/enQtNDYyODAxNDY4MjQxLWU1OTBjOWJjOTA1MmE5YjIwMTM5MjFhZGMwM2YzYTEzYTdhNGIzMTFiZjI1NTlhYTkzNGQ5MjBkYzE5YjMyMTE">invite</a>)</li>
+              <li><a style="display: inline;" href="https://bazelbuild.slack.com">Slack</a> (get an <a style="display: inline;" href="https://bazel-slackin.herokuapp.com">invite</a>)</li>
             </ul>
           </nav>
         </div>

--- a/contributing.md
+++ b/contributing.md
@@ -17,7 +17,7 @@ Please check with us on the [dev
 list](https://groups.google.com/forum/#!forum/bazel-dev) before investing a lot
 of time in a patch. Meet Bazel maintainers and other contributors on
 [Slack](https://bazelbuild.slack.com) (get an [invite
-here](https://join.slack.com/t/bazelbuild/shared_invite/enqtndyyodaxndy4mjqxlwu1otbjowjjota1mme5yjiwmtm5mjfhzgmwm2yzytezytdhngizmtfizji1ntlhytkzngq5mjbkyze5yjmymte)).
+here](https://bazel-slackin.herokuapp.com)).
 
 ### Patch Acceptance Process
 

--- a/support.md
+++ b/support.md
@@ -10,7 +10,7 @@ title: Get Support
 * Discuss on the [User mailing list](https://groups.google.com/forum/#!forum/bazel-discuss).
 * Report bugs or feature requests in our [GitHub issue tracker](https://github.com/bazelbuild/bazel/issues).
 * Find other Bazel contributors on [Slack](https://bazelbuild.slack.com) (get an [invite
-here](https://join.slack.com/t/bazelbuild/shared_invite/enqtndyyodaxndy4mjqxlwu1otbjowjjota1mme5yjiwmtm5mjfhzgmwm2yzytezytdhngizmtfizji1ntlhytkzngq5mjbkyze5yjmymte)).
+here](https://bazel-slackin.herokuapp.com)).
 
 # Support Policy
 
@@ -288,4 +288,3 @@ These rules and features have known limitations that we will likely address in f
       </td>
   </tbody>
 </table>
-


### PR DESCRIPTION
Fixes #167 (at least temporarily), [people are confused](https://twitter.com/marcpl31/status/1117963034218192896) and we need to provide at least some solution in the mean time.

It would be good if you could get some domain name (like [`bazel-slack.dev`](https://domains.google.com/m/registrar/search?searchTerm=bazel-slack.dev&hl=en) and CNAME it to `bazel-slackin.herokuapp.com` so that it could be changed without modifications to the url