### PR TITLE
Update Slack links to use the new slack.bazel.build

### DIFF
--- a/_layouts/contribute.html
+++ b/_layouts/contribute.html
@@ -47,7 +47,7 @@ nav: contribute
               <li><a href="https://source.bazel.build/">Search Bazel code</a></li>
               <li><a href="/browse-and-search-user-guide.html">Search user guide</a></li>
               <li><a href="https://groups.google.com/forum/#!forum/bazel-dev">Developer mailing list</a></li>
-              <li><a style="display: inline;" href="https://bazelbuild.slack.com">Slack</a> (get an <a style="display: inline;" href="https://bazel-slackin.herokuapp.com">invite</a>)</li>
+              <li><a href="https://slack.bazel.build">Slack</a></li>
             </ul>
           </nav>
         </div>

--- a/contributing.md
+++ b/contributing.md
@@ -16,8 +16,7 @@ stylistic, refactoring, or "cleanup" changes).
 Please check with us on the [dev
 list](https://groups.google.com/forum/#!forum/bazel-dev) before investing a lot
 of time in a patch. Meet Bazel maintainers and other contributors on
-[Slack](https://bazelbuild.slack.com) (get an [invite
-here](https://bazel-slackin.herokuapp.com)).
+[Slack](https://slack.bazel.build).
 
 ### Patch Acceptance Process
 

--- a/support.md
+++ b/support.md
@@ -9,8 +9,12 @@ title: Get Support
 `bazel` tag.
 * Discuss on the [User mailing list](https://groups.google.com/forum/#!forum/bazel-discuss).
 * Report bugs or feature requests in our [GitHub issue tracker](https://github.com/bazelbuild/bazel/issues).
+<<<<<<< Updated upstream
 * Find other Bazel contributors on [Slack](https://bazelbuild.slack.com) (get an [invite
 here](https://bazel-slackin.herokuapp.com)).
+=======
+* Find other Bazel contributors on [Slack](https://slack.bazel.build).
+>>>>>>> Stashed changes
 
 # Support Policy
 

--- a/support.md
+++ b/support.md
@@ -9,12 +9,7 @@ title: Get Support
 `bazel` tag.
 * Discuss on the [User mailing list](https://groups.google.com/forum/#!forum/bazel-discuss).
 * Report bugs or feature requests in our [GitHub issue tracker](https://github.com/bazelbuild/bazel/issues).
-<<<<<<< Updated upstream
-* Find other Bazel contributors on [Slack](https://bazelbuild.slack.com) (get an [invite
-here](https://bazel-slackin.herokuapp.com)).
-=======
 * Find other Bazel contributors on [Slack](https://slack.bazel.build).
->>>>>>> Stashed changes
 
 # Support Policy
 


### PR DESCRIPTION
Fixes https://github.com/bazelbuild/bazel/issues/7046

