### PR TITLE
Deduplicate the release policy in favor of the playbook

### DIFF
--- a/support.md
+++ b/support.md
@@ -45,34 +45,14 @@ reported issues within 2 business days.
 
 ## Releases
 
-We regularly publish [binary releases of Bazel](https://github.com/bazelbuild/bazel/releases).
-
-### Policy
-
-Every beginning of the month (we target the first business day of the month), we create a new release
-candidate for a new MINOR version (e.g. 0.6.0). The work is tracked by a [release bug on GitHub](https://github.com/bazelbuild/bazel/issues?q=is%3Aissue+is%3Aopen+label%3Arelease) which indicates
-the exact target date for the incoming month and assigned to the current Release Manager.
-Those release candidates should pass all our unit tests, and show no unwanted regression in the
-projects tested on [ci.bazel.io](http://ci.bazel.io).
-
-We announce those release candidates on [bazel-discuss](https://groups.google.com/forum/#!forum/bazel-discuss).
-Over the next days, we monitor community bug reports for regressions in release candidate.
-
-If no regressions are discovered, we officially release the candidate after one week. However,
-regressions can delay the release of a release candidate. If regressions are found, we apply
-corresponding cherry-picks to the release candidate to fix those regressions. If no further
-regressions are found for two business days, but not before one week has elapsed since the first
-release candidate, we release it.
-
-After a release candidate is cut, we do not cherry-pick new features into it.
-Moreover, if we discover that a new feature is buggy, we might decide to roll it back from a
-release candidate. Only critical, high-impact bugs will be fixed in a release candidate.
-
-A release can only be released on a day where the next day is a business day.
-
-If a critical issue is found on the latest release, a patch release can be emitted by applying the
-corresponding cherry-pick to the release tag. Being another patch to an existing release, the
-release candidate for a patch release can be released after 2 business days.
+We regularly, usualy once a month, publish
+[binary releases of Bazel](https://github.com/bazelbuild/bazel/releases). Here
+we follow the process outlined in the
+[Bazel release playbook](https://github.com/bazelbuild/continuous-integration/blob/master/docs/release-playbook.md),
+in particular the
+[release policy](https://github.com/bazelbuild/continuous-integration/blob/master/docs/release-playbook.md#push-a-release)
+descrbed there. Progress on the individual releases can observed by following
+the [release bugs on GitHub](https://github.com/bazelbuild/bazel/issues?q=is%3Aissue+is%3Aopen+label%3Arelease).
 
 ### Post-mortems
 


### PR DESCRIPTION
Two avoid having two sources describing our release policy, remove
the one on the website in favor of a reference to our public release
play book.

Note: by this change we're dropping the requirement "A release can
only be released on a day where the next day is a business day."
which has never been an issue for an open-source release anyway.