### PR TITLE
"Get Bazel" button now looks like "Get Started"

### DIFF
--- a/index.html
+++ b/index.html
@@ -10,7 +10,7 @@ title: Bazel - a fast, scalable, multi-language and extensible build system"
           <p class="hero-tagline">{Fast, Correct} - Choose two</p>
           <h1 class="hero-title">Build and test software of any size, quickly and reliably</h1>
           <p class="cta-buttons">
-            <a class="btn btn-lg"
+            <a class="btn btn-success btn-lg"
                id="btn-install"
                href="{{ site.docs_site_url }}/install.html">
                Get Bazel


### PR DESCRIPTION
I can't explain why they always looked different
despite both being buttons.