### PR TITLE
Remove the "Getting Started" section on the front-page.

### DIFF
--- a/index.html
+++ b/index.html
@@ -137,38 +137,6 @@ title: Bazel - a fast, scalable, multi-language and extensible build system"
     </div>
   </div>
 
-  <div class="landing-section get-started">
-    <div class="container">
-      <div class="row">
-        <div class="col-sm-12">
-          <h2>Get Started</h2>
-        </div>
-      </div>
-      <div class="row">
-        <div class="col-sm-6 col-md-3">
-          <h3>Java</h3>
-          <p>Follow our <a href="{{ site.docs_site_url }}/tutorial/java.html">Build Java tutorial</a>.
-          </p>
-        </div>
-        <div class="col-sm-6 col-md-3">
-          <h3>C++</h3>
-          <p>Follow our <a href="{{ site.docs_site_url }}/tutorial/cpp.html">Build C++ tutorial</a>.
-          </p>
-        </div>
-        <div class="col-sm-6 col-md-3">
-          <h3>Android</h3>
-          <p>Follow our <a href="{{ site.docs_site_url }}/tutorial/android-app.html">mobile app tutorial</a>.
-          </p>
-        </div>
-        <div class="col-sm-6 col-md-3">
-          <h3>iOS</h3>
-          <p>Follow our <a href="{{ site.docs_site_url }}/tutorial/ios-app.html">mobile app tutorial</a>.
-          </p>
-        </div>
-      </div>
-    </div>
-  </div>
-
   <div class="beta">
     <div class="container">
       <div class="row">


### PR DESCRIPTION
- There's already a "Get Started" button at the top.
- Bazel is a multilanguage tool, this section was a bit misleading.