### PR TITLE
Synchronize release scripts and styles from docs.bazel.build to www.bazel.build

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -8,10 +8,29 @@ highlighter: rouge
 paginate: 10
 sass:
   sass_dir: _sass
-gems: [jekyll-paginate]
+gems:
+  - jekyll-paginate
+  - jekyll-toc
+  - jekyll-sitemap
 
 main_site_url: ""
 blog_site_url: https://blog.bazel.build
 docs_site_url: https://docs.bazel.build
 
 assets_url: https://bazel.build
+
+defaults:
+  # Enable table of contents for every page
+  -
+    scope:
+      path: ""
+    values:
+      toc: true
+      sitemap: true
+
+# jekyll-toc settings
+toc:
+  min_level: 2
+  max_level: 3
+  list_class: page-toc
+  sublist_class: page-toc-sublist

--- a/_includes/head.html
+++ b/_includes/head.html
@@ -31,7 +31,7 @@
     <link rel="canonical" href="{{ page.url | replace:'index.html','' | prepend: site_root }}">
 
     <!-- Webfont -->
-    <link href="//fonts.googleapis.com/css?family=Roboto:300,400,500|Source+Code+Pro:400,500,700" rel="stylesheet">
+    <link href="//fonts.googleapis.com/css?family=Source+Code+Pro:400,500,700|Open+Sans:400,600,700,800" rel="stylesheet">
 
     <link rel="icon" type="image/png" href="/images/favicon-32x32.png" sizes="32x32">
     <link rel="icon" type="image/png" href="/images/favicon-16x16.png" sizes="16x16">

--- a/_layouts/contribute.html
+++ b/_layouts/contribute.html
@@ -8,15 +8,9 @@ nav: contribute
   <body>
     {% include header.html %}
 
-    <div class="page-title-bar">
-      <div class="container">
-        <h1>Contribute</h1>
-      </div>
-    </div>
-
     <div class="container vpad">
       <div class="row">
-        <div class="col-lg-3">
+        <div class="col-md-2">
           <a class="btn btn-default btn-lg btn-block sidebar-toggle"
               data-toggle="collapse" href="#sidebar-nav" aria-expanded="false"
               aria-controls="sidebar-nav">
@@ -53,8 +47,17 @@ nav: contribute
             </ul>
           </nav>
         </div>
-        <div class="col-lg-9">
+        <div class="col-md-8">
           {{ content }}
+        </div>
+
+        <div class="col-md-2 sticky-sidebar">
+          <div class="right-sidebar">
+            <ul class="gh-links">
+                <li><a href="https://github.com/bazelbuild/bazel/issues/new?title=Documentation issue: {{ page.title }}&body=Documentation URL: https://docs.bazel.build{{ page.url }}&labels=type: documentation"><i class="fa fa-github"></i> Create issue</a></li>
+            </ul>
+            {{ content | toc_only }}
+          </div>
         </div>
       </div>
     </div>

--- a/_sass/home.scss
+++ b/_sass/home.scss
@@ -1,3 +1,5 @@
+// Styles specific to the landing page on www.bazel.build
+
 $landing-bg-color: #fafafa;
 
 .body-home {
@@ -152,5 +154,15 @@ $landing-bg-color: #fafafa;
       width: 380px;
       padding-right: 30px;
       padding-top: 15px;
+  }
+}
+
+@media (min-width: 1200px) {
+  .home .container {
+    width: 1170px;
+  }
+
+  .footer .container {
+    width: 1170px;
   }
 }

--- a/_sass/sidebar.scss
+++ b/_sass/sidebar.scss
@@ -1,8 +1,29 @@
-$sidebar-border-color: #fff;
+// Sidebar styles for all Bazel web assets.
+//
+// For consistency, this file should be identical across docs.bazel.build,
+// blog.bazel.build and www.bazel.build.
+// TODO(https://github.com/bazelbuild/bazel/issues/10793): Extract into single source of truth.
+
+$sidebar-border-color: #dee2e6;
+
 $sidebar-hover-border-color: #66bb6a;
 
 .sidebar {
-  margin-top: 40px;
+  border-right: 1px solid $sidebar-border-color;
+  background-color: rgba(67,160,71,.03);
+  padding-top: 40px;
+  padding-left: 1.5rem;
+
+  // override parent row padding-left. bootstrap's default is 15px.
+  margin-left: -15px;
+
+  li {
+    font-size: $font-size-base * .95;
+  }
+
+  h4 {
+    padding-right: 1rem;
+  }
 
   ul.sidebar-nav {
     list-style-type: none;
@@ -14,13 +35,22 @@ $sidebar-hover-border-color: #66bb6a;
         margin: 0;
         display: block;
         font-size: 16px;
-        font-weight: 300;
+        font-weight: $font-weight-light;
+      }
+
+      ul {
+        li {
+          a {
+            color: #495057;
+          }
+        }
       }
 
       a {
-        padding: 4px 0;
+        padding: 4px 1rem 4px 0;
         display: block;
-        border-right: 2px solid $sidebar-border-color;;
+        color: #222;
+        font-weight: $font-weight-normal;
 
         &:focus {
           text-decoration: none;
@@ -28,20 +58,22 @@ $sidebar-hover-border-color: #66bb6a;
 
         &:active,
         &:hover {
-          border-right: 2px solid $sidebar-hover-border-color;
+          border-right: 4px solid $sidebar-hover-border-color;
           text-decoration: none;
         }
 
         .caret {
           float: right;
           margin-top: 8px;
-          margin-right: 10px;
+          margin-right: 0px;
         }
+
       }
 
       &.active {
         a {
-          border-right: 2px solid $sidebar-hover-border-color;
+          border-right: 4px solid $sidebar-hover-border-color;
+          font-weight: $font-weight-bold;
         }
       }
     }
@@ -49,6 +81,23 @@ $sidebar-hover-border-color: #66bb6a;
     ul.sidebar-nav {
       padding-left: 10px;
     }
+  }
+
+  select {
+    padding: 3px 4px;
+    border: 2px solid $sidebar-border-color;
+    border-radius: 3px;
+    width: 80%;
+  }
+}
+
+.sidebar-toggle {
+  margin-top: 50px;
+}
+
+@media (max-width: 991px) {
+  .right-sidebar {
+    display: none;
   }
 }
 
@@ -60,6 +109,60 @@ $sidebar-hover-border-color: #66bb6a;
   .sidebar {
     &.collapse {
       display: block;
+    }
+  }
+
+  .sticky-sidebar {
+    @supports (position: sticky) {
+      position: sticky;
+      top: 50px; // equals height of navbar.
+      height: calc(95vh);
+      overflow-y: auto;
+    }
+  }
+}
+
+.right-sidebar {
+  border-left: 1px solid $sidebar-border-color;
+  padding-top: 1rem;
+  padding-bottom: 1rem;
+  padding-left: 1em;
+
+  .gh-links {
+    padding-left: 0;
+    list-style-type: none;
+    li {
+      padding-bottom: .4rem;
+    }
+  }
+
+  a {
+    font-weight: $font-weight-normal;
+  }
+}
+
+.page-toc {
+  padding-left: 0;
+  list-style-type: none;
+
+  li {
+    margin-top: .3rem;
+    line-height: 1.7;
+    font-size: $font-size-base * .95;
+    a {
+      color: #444;
+    }
+  }
+}
+
+.page-toc-sublist {
+  padding-left: 1em;
+  list-style-type: none;
+
+  li {
+    line-height: 1.7;
+    a {
+      color: #666;
     }
   }
 }

--- a/_sass/style.scss
+++ b/_sass/style.scss
@@ -1,3 +1,30 @@
+// Base styles for all Bazel web assets.
+//
+// For consistency, this file should be identical across docs.bazel.build,
+// blog.bazel.build and www.bazel.build.
+// TODO(https://github.com/bazelbuild/bazel/issues/10793): Extract into single source of truth.
+
+// Heading sizes
+
+$font-size-base: 14px !default;
+
+$h1-font-size: $font-size-base * 2.25 !default;
+$h2-font-size: $font-size-base * 2 !default;
+$h3-font-size: $font-size-base * 1.5 !default;
+$h4-font-size: $font-size-base * 1.35 !default;
+$h5-font-size: $font-size-base * 1.15 !default;
+$h6-font-size: $font-size-base !default;
+
+// Font weights
+
+$font-weight-light: 300 !default;
+$font-weight-normal: 400 !default;
+$font-weight-medium: 500 !default;
+$font-weight-bold: 700 !default;
+
+$font-weight-body-text: $font-weight-normal !default;
+$headings-font-weight: $font-weight-medium !default;
+
 // Bazel logo colors
 $bazel-green: #43a047;
 $bazel-green-light: #76d275;
@@ -5,31 +32,41 @@ $bazel-green-dark-left: #00701a;
 $bazel-green-dark-right: #004300;
 $color-on-bazel-green: #fff;
 
-$body-font-family: 'Roboto', 'Helvetica Neue', Helvetica, Arial,
+$body-font-family: 'Open Sans', 'Helvetica Neue', Helvetica, Arial,
                    sans-serif;
-$code-font-family: 'Source Code Pro', monospace;
+$code-font-family: 'Monaco', 'Source Code Pro', monospace;
 
-$link-color: $bazel-green;
-$link-hover-color: darken($link-color, 10%);
-$well-color: #f9f9f9;
-$text-color: #444;
+$link-color: $bazel-green-dark-left;
+$link-hover-color: lighten($link-color, 20%);
+$well-color: #eee;
+$code-color: #000;
+$text-color: #000;
 
-$vpad: 20px;
+$vpad: 0px;
 
+$table-bg: #fff;
+$table-cell-padding: 5px;
+$table-border-color: $bazel-green;
+$text-muted: $color-on-bazel-green;
+$line-height-base: 1.5;
+$line-height-computed: 1.5;
 
 html {
   position: relative;
   min-height: 100%;
+  font-size: 100%;
 }
 
 body {
   padding-top: 50px;
   color: $text-color;
   font-family: $body-font-family;
+  line-height: $line-height-base;
 }
 
 a {
   color: $link-color;
+  font-weight: $font-weight-medium;
 
   &:hover,
   &:focus {
@@ -48,9 +85,8 @@ h4,
 h5,
 h6 {
   color: $text-color;
-  font-weight: 400;
-  margin-top: 30px;
-  margin-bottom: 15px;
+  margin-top: 2rem;
+  margin-bottom: 1rem;
 }
 
 h1 code,
@@ -64,12 +100,12 @@ h6 code {
 }
 
 h1 {
-  margin-top: 40px;
+  font-size: $h1-font-size;
+  font-weight: $font-weight-bold;
 }
 
 h2 {
-  font-size: 24px;
-  margin-top: 30px;
+  font-size: $h2-font-size;
 
   code {
     font-size: 24px;
@@ -77,7 +113,7 @@ h2 {
 }
 
 h3 {
-  font-size: 20px;
+  font-size: $h3-font-size;
 
   code {
     font-size: 20px;
@@ -85,45 +121,84 @@ h3 {
 }
 
 h4 {
-  font-size: 18px;
+  font-size: $h4-font-size;
 
   code {
     font-size: 18px;
   }
 }
 
+h5 {
+  font-size: $h5-font-size;
+}
+
+h6 {
+  font-size: $h6-font-size;
+}
+
 p,
 li {
-  font-size: 14px;
-  line-height: 22px;
+  font-size: $font-size-base;
+  line-height: $line-height-base;
 }
 
 pre {
   padding: 8px 16px;
+  margin: 8px 0;
   font-family: $code-font-family;
   background-color: $well-color;
   border: 0;
-  font-size: 13px;
+  font-size: 100%;
   line-height: 20px;
+  color: $code-color;
+  border-radius: 6px;
+  box-shadow: 1px 1px 5px #aaa;
 }
 
 code {
   font-family: $code-font-family;
   font-size: 13px;
   background-color: $well-color;
+  color: $code-color;
 }
 
 
-// Immitate material design buttons
+// Imitate material design buttons
 .btn-lg {
   font-size: 14px;
   text-transform: uppercase;
 }
 
+$md-shadow-1: rgba(0, 0, 0, .14);
+$md-shadow-2: rgba(0, 0, 0, .2);
+$md-shadow-3: rgba(0, 0, 0, .12);
+
+
+@media (min-width: 768px) {
+  .container {
+    width: 100%;
+    max-width: 100%;
+  }
+}
+
+@media (min-width: 992px) {
+  .content {
+    max-width: 85%;
+  }
+}
+
+.content {
+  padding: 40px 10px;
+  p {
+    line-height: 22px;
+    margin-bottom: 1rem;
+  }
+}
+
 .btn-success {
   border-radius: 2px;
-  box-shadow: 0 2px 2px 0 rgba(0,0,0,.14), 0 3px 1px -2px rgba(0,0,0,.2), 0 1px 5px 0 rgba(0,0,0,.12);
-  border: none;
+  box-shadow: 0 2px 2px 0 $md-shadow-1, 0 3px 1px -2px $md-shadow-2, 0 1px 5px 0 $md-shadow-3;
+  border: 0;
 }
 
 .well {
@@ -148,7 +223,7 @@ code {
   h4,
   h5,
   h6 {
-    margin: 8px 0 4px 0;
+    margin: 8px 0 4px;
     color: $color-on-bazel-green;
   }
 }
@@ -161,4 +236,17 @@ code {
     -moz-box-sizing: content-box !important;
     box-sizing: content-box !important;
   }
+}
+
+// Used for the Command-line Reference flag anchors. Linkifying the flag name
+// causes it to turn $link-color (green), but we turn it red here to be consistent
+// with the rest of the code block.
+dd > code > a,
+dl > dt > code > a {
+  color: $code-color;
+}
+
+dl > dt {
+  margin-top: 1.5rem;
+  margin-bottom: .5rem;
 }

--- a/scripts/Dockerfile
+++ b/scripts/Dockerfile
@@ -15,11 +15,20 @@
 #
 # Then access the website in your browser via http://localhost:8000
 
-FROM gcr.io/cloud-builders/bazel
+FROM ubuntu:18.04
 
-RUN apt-get update && \
-  apt-get -y install ruby ruby-dev build-essential python-pygments && \
-  apt-get clean && rm -rf /var/lib/apt/lists/*
+ENV DEBIAN_FRONTEND="noninteractive"
+RUN apt-get -qqy update && \
+    apt-get -qqy install build-essential curl liblzma-dev python3.7 \
+      python-pygments ruby ruby-dev unzip zlib1g-dev && \
+    apt-get clean && rm -rf /var/lib/apt/lists/*
+
+RUN ln -fs /usr/bin/python3.7 /usr/bin/python
+
+RUN curl -Lo /usr/local/bin/bazel https://github.com/bazelbuild/bazelisk/releases/download/v1.3.0/bazelisk-linux-amd64 && \
+    chown root:root /usr/local/bin/bazel && \
+    chmod 0755 /usr/local/bin/bazel
+RUN bazel version
 
 COPY Gemfile .
 RUN gem install -g --no-rdoc --no-ri && rm -f Gemfile

--- a/scripts/Gemfile
+++ b/scripts/Gemfile
@@ -1,20 +1,12 @@
-gem 'jekyll', '3.1.6'
+# Ruby dependencies for all Bazel web assets.
 
-# Jekyll 3.1.6 automatically depends on these Gems:
-# (see https://github.com/jekyll/jekyll/blob/v3.1.6/jekyll.gemspec)
-#
-# 'liquid',       '~> 3.0'
-# 'kramdown',     '~> 1.3'
-# 'mercenary',    '~> 0.3.3'
-# 'safe_yaml',    '~> 1.0'
-# 'colorator',    '~> 0.1'
-# 'rouge',        '~> 1.7'
-# 'jekyll-sass-converter', '~> 1.0'
-# 'jekyll-watch', '~> 1.1'
+# For consistency, this file should be identical across docs.bazel.build,
+# blog.bazel.build and www.bazel.build.
+# TODO(https://github.com/bazelbuild/bazel/issues/10793): Extract into single source of truth.
 
-# These are additional Gems whose versions I fixed to the ones mentioned in Jekyll 3.1.6's Gemfile.
-# (see https://github.com/jekyll/jekyll/blob/v3.1.6/Gemfile#L55)
-
+gem 'jekyll', '~> 3.8.6'
 gem 'jekyll-paginate', '~> 1.0'
 gem 'pygments.rb', '~> 0.6.0'
 gem 'redcarpet', '~> 3.2', '>= 3.2.3'
+gem 'jekyll-toc', '~> 0.13.1'
+gem 'jekyll-sitemap', '~> 1.4.0'

--- a/scripts/cloudbuild.yaml
+++ b/scripts/cloudbuild.yaml
@@ -2,8 +2,12 @@ steps:
 - name: gcr.io/cloud-builders/docker
   args: ['build', '--tag=gcr.io/$PROJECT_ID/bazel-jekyll', 'scripts']
 - name: gcr.io/$PROJECT_ID/bazel-jekyll
+  args: ['bazel', 'version']
+- name: gcr.io/$PROJECT_ID/bazel-jekyll
   args: ['build', '--action_env=PATH=/usr/local/bin:/usr/bin:/bin', '//:site']
 - name: gcr.io/cloud-builders/gsutil
   args: ['-m', 'rsync', '-r', '-c', '-d', '/workspace/bazel-bin/site-build', 'gs://www.bazel.build']
 - name: gcr.io/cloud-builders/gsutil
   args: ['web', 'set', '-m', 'index.html', '-e', '404.html', 'gs://www.bazel.build']
+
+timeout: 600s # 10 minutes


### PR DESCRIPTION
[1/2] of https://github.com/bazelbuild/bazel/issues/10793 ([2/2] being bazel-blog)

The plan is to first make sure that the common styles are synced across sites with a bit of duplication, then extract them out to a single source of truth.

Staging site: 
https://wizardly-curran-963021.netlify.app/ (home page)
https://wizardly-curran-963021.netlify.app/contributing.html 