### PR TITLE
Wrap content with a div with 'content' class to apply CSS from base styles

### DIFF
--- a/_layouts/contribute.html
+++ b/_layouts/contribute.html
@@ -54,7 +54,9 @@ nav: contribute
           </nav>
         </div>
         <div class="col-md-8">
-          {{ content }}
+          <div class="content">
+            {{ content }}
+          </div>
         </div>
 
         <div class="col-md-2 sticky-sidebar">


### PR DESCRIPTION
For docs.bazel.build: https://github.com/bazelbuild/bazel/blob/dcbbc9ddf319270f178110203c177f1b0e6b18a8/site/_layouts/documentation.html#L358-L362

Specifically this constraints the width of the content to 85% for shorter lines.

https://www.bazel.build/contributing.html

vs

https://docs.bazel.build/versions/3.1.0/bazel-vision.html