### PR TITLE
Home page: Remove the "Get Bazel" button.

### DIFF
--- a/index.html
+++ b/index.html
@@ -10,11 +10,6 @@ title: Bazel - a fast, scalable, multi-language and extensible build system"
           <p class="hero-tagline">{Fast, Correct} - Choose two</p>
           <h1 class="hero-title">Build and test software of any size, quickly and reliably</h1>
           <p class="cta-buttons">
-            <a class="btn btn-lg"
-               id="btn-install"
-               href="{{ site.docs_site_url }}/install.html">
-               Get Bazel
-            </a>
             <a class="btn btn-success btn-lg cta-main"
                href="{{ site.docs_site_url }}/getting-started.html">
                Get Started


### PR DESCRIPTION
The "Get Started" button is the main one and contains all the
information that's needed. Simplify the page by removing the superfluous
button.

For a full discussion, see https://github.com/bazelbuild/bazel-website/pull/190