### PR TITLE
Fix Build API roadmap link

### DIFF
--- a/roadmap.md
+++ b/roadmap.md
@@ -8,5 +8,5 @@ title: Roadmap
 ## Roadmaps for specific Bazel areas
 
 *  [Configurability](roadmaps/configuration.html)
-*  [Build API](roadmaps/build-api.md)
+*  [Build API](roadmaps/build-api.html)
 *  [Starlark](roadmaps/starlark.html)


### PR DESCRIPTION
Interestingly `.html` is required for https://bazel.build/roadmap.html to work while `.md` is required for https://github.com/bazelbuild/bazel-website/blob/master/roadmap.md to work.