### PR TITLE
Fix home page's Get Started 404 error

### DIFF
--- a/index.html
+++ b/index.html
@@ -11,7 +11,7 @@ title: Bazel - a fast, scalable, multi-language and extensible build system"
           <h1 class="hero-title">Build and test software of any size, quickly and reliably</h1>
           <p class="cta-buttons">
             <a class="btn btn-success btn-lg cta-main"
-               href="{{ site.docs_site_url }}/getting-started.html">
+               href="{{ site.getting_started_category_url }}">
                Get Started
             </a>
           </p>


### PR DESCRIPTION
It's currently broken, linking to https://docs.bazel.build/guide.html/getting-started.html