### PR TITLE
Add JDB connect string for Windows.

### DIFF
--- a/basics/getting_started.md
+++ b/basics/getting_started.md
@@ -114,7 +114,7 @@ However, to debug Java code, attach to the server using the following:
 *  Run Bazel with the debugging option `--host_jvm_debug` before the
    command (e.g., `bazel --host_jvm_debug build //src:bazel`).
 *  Attach a debugger to the port 5005. For instance, with `jdb`,
-   run `jdb -attach localhost:5005`.
+   run `jdb -attach localhost:5005` (`jdb.exe -connect com.sun.jdi.SocketAttach:hostname=localhost,port=5005` for Windows).
 
 Our IntelliJ plugin has built-in [debugging support](https://ij.bazel.build/docs/run-configurations.html).
 


### PR DESCRIPTION
JDB doesn't use socket debug transport by default.
So user must specify transport in a command line.