### PR TITLE
Remove FAQ reference to "basil" (the herb)

### DIFF
--- a/faq.md
+++ b/faq.md
@@ -346,5 +346,4 @@ applications, such as Chrome.
 
 ## How do you pronounce "Bazel"?
 
-The same way as "basil" (the herb) in US English: "BAY-zel". It rhymes with
-"hazel". IPA: /ˈbeɪzˌəl/
+It's pronounced "BAY-zel". It rhymes with "hazel". IPA: /ˈbeɪzˌəl/


### PR DESCRIPTION
The FAQ entry "How do you pronounce 'Bazel'" says it's pronounced the same as "basil" (the herb), and then gives the "BAY-zel" pronunciation.

This makes things hopelessly confusing, as basil can be correctly pronounced _either_ to rhyme with "hazel" or to rhyme with "frazzle". In fact, many dictionaries list the "rhymes with frazzle" pronunciation first, with "rhymes with hazel" as a secondary pronunciation:

https://www.dictionary.com/browse/basil

https://www.merriam-webster.com/dictionary/basil

So I removed the "basil" reference entirely to avoid this confusion.