### PR TITLE
Remove Obj-C targets from Getting Started page

### DIFF
--- a/basics/getting_started.md
+++ b/basics/getting_started.md
@@ -78,7 +78,7 @@ The resulting binary can be found at `bazel-bin/src/bazel`. This is the
 recommended way of rebuilding Bazel once you have bootstrapped it.
 
 In addition to the Bazel binary, you might want to build the various tools Bazel
-uses. They are located in `//src/java_tools/...`, `//src/objc_tools/...` and
+uses. They are located in `//src/java_tools/...` and
 `//src/tools/...` and their directories contain README files describing their
 respective utility.
 


### PR DESCRIPTION
The Obj-C targets are mentioned in Getting Started page, but they were removed in bazelbuild/bazel@32246b2b60.
This PR removes the removed targets from the page.