### PR TITLE
Added reference to Google's OSS Code of Conduct

### DIFF
--- a/contributing.md
+++ b/contributing.md
@@ -60,5 +60,5 @@ To learn about how to submit a change, see the [patch acceptance process](basics
 
 ## Code of Conduct
 Contributing to Bazel should be a pleasant and inclusive experience for everyone. This
-[code of conduct](https://github.com/bazelbuild/bazel/blob/master/CODE_OF_CONDUCT.md) applies to
+[code of conduct](https://github.com/bazelbuild/bazel/blob/HEAD/CODE_OF_CONDUCT.md) applies to
 all interactions within the Bazel project.


### PR DESCRIPTION
Added to contributing.md as temporary solution. I assume that eventually it should be accessible through the top level navigation, like in the "About" section for example.