### PR TITLE
Add deprecation notice to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,39 +1,8 @@
-# Bazel website https://bazel.build
+# Legacy Bazel website
 
-This repository hosts the content of the Bazel website, available at https://bazel.build/
-It does not contain the [Bazel documentation](https://github.com/bazelbuild/bazel/tree/master/site/docs) or the [Bazel blog](https://github.com/bazelbuild/bazel-blog).
+This repository hosts the contents of the **legacy** Bazel website. Right now its only purpose is to host old design docs, which we'll eventuall port over to the new site.
 
-## Prerequisites
+If you want to make changes please look here instead:
 
-To build the site, you will need [Jekyll](http://jekyllrb.com) version 2.5.3 or
-above. For instance, it can be installed with `apt-get install jekyll` on recent
-Ubuntu (tested on 16.10).
-
-```
-sudo apt-get install jekyll ruby-jekyll-paginate ruby-jekyll-sitemap ruby-jekyll-toc ruby-kramdown-parser-gfm
-```
-
-To deploy the site, you will need [gsutil](https://cloud.google.com/storage/docs/gsutil)
-and to authenticate with `gcloud auth login`.
-
-## Running the website locally
-
-To stage the site
-
-```
-bazel run //:site
-```
-
-If you want to show the preview to others
-
-```
-HOST=$(hostname) bazel run //:site
-```
-
-See [the Jekyll site](http://jekyllrb.com/docs) if you need more info.
-
-## Deploying the website
-
-Deploying the website is done automatically through Google Cloud Container Builder.
-If for some reason it does not work, you can run `bazel run //:site -- --push` to deploy
-manually.
+- The source files of https://bazel.build/ live at https://github.com/bazelbuild/bazel/tree/master/site/en
+- The [Bazel blog](https://github.com/bazelbuild/bazel-blog) is a separate GitHub repository.


### PR DESCRIPTION
https://bazel.build/ is now hosted on a different system, which is completely independent of this repository.

For now we should keep it around since we haven't migrated the design docs yet (and some of the roadmaps, too).