### PR TITLE
Update BE redirect to point to new site

### DIFF
--- a/_includes/head.html
+++ b/_includes/head.html
@@ -10,11 +10,11 @@
       // Do a shortcut so that be.bazel.build redirect to the build encyclopedia
       var be_url = new RegExp("^https?://be(\.bazel.build)?/?");
       if (be_url.test(current_url)) {
-        window.location.replace(current_url.replace(be_url, "https://docs.bazel.build/be/overview.html"));
+        window.location.replace(current_url.replace(be_url, "https://bazel.build/reference/be/overview"));
       }
       var be_url = new RegExp("^https?://be(\.bazel.build)?/([a-zA-Z0-9_-]+)([/#](.*))?");
       if (be_url.test(current_url)) {
-        window.location.replace(current_url.replace(be_url, "https://docs.bazel.build/be/$2.html#$4"));
+        window.location.replace(current_url.replace(be_url, "https://bazel.build/reference/be/$2#$4"));
       }
       // And a short to code reviews
       var cr_url = new RegExp("^https?://cr(\.bazel.build)?/([0-9]+)")


### PR DESCRIPTION
be.bazel.build should redirect users to bazel.build/reference/be, not to the old site at docs.bazel.build.

Progress towards https://github.com/bazelbuild/bazel/issues/15483